### PR TITLE
Fix for offset_encoding_error.

### DIFF
--- a/lua/cosmic-ui/code-action/init.lua
+++ b/lua/cosmic-ui/code-action/init.lua
@@ -36,7 +36,7 @@ end
 local function execute_action(action)
   if action.edit or type(action.command) == 'table' then
     if action.edit then
-      vim.lsp.util.apply_workspace_edit(action.edit)
+      vim.lsp.util.apply_workspace_edit(action.edit, 'utf-8')
     end
     if type(action.command) == 'table' then
       vim.lsp.buf.execute_command(action.command)


### PR DESCRIPTION
Fixes https://github.com/CosmicNvim/CosmicNvim/issues/65
As per `:h apply_workspace_edit` offset_encoding is required as a string. May want to make this configurable.