### PR TITLE
fixed the width calculation of the renaming window (#4)

### DIFF
--- a/lua/cosmic-ui/rename/init.lua
+++ b/lua/cosmic-ui/rename/init.lua
@@ -11,7 +11,7 @@ local function rename(popup_opts, opts)
   local user_border = _G.CosmicUI_user_opts.rename.border
   local width = 25
   if #curr_name + 3 > width then
-    -- consider border (+2) and on free space, otherwise the textbox scrolls
+    -- consider border (+2) and one free space, otherwise the textbox scrolls
     -- and shows an -- seemingly -- empty textbox
     width = #curr_name + 3
   end

--- a/lua/cosmic-ui/rename/init.lua
+++ b/lua/cosmic-ui/rename/init.lua
@@ -10,10 +10,10 @@ local function rename(popup_opts, opts)
 
   local user_border = _G.CosmicUI_user_opts.rename.border
   local width = 25
-  if #curr_name + 3 > width then
-    -- consider border (+2) and one free space, otherwise the textbox scrolls
+  if #curr_name + #_G.CosmicUI_user_opts.rename.prompt >= width then
+    -- consider prompt and one free space, otherwise the textbox scrolls
     -- and shows an -- seemingly -- empty textbox
-    width = #curr_name + 3
+    width = #curr_name + #_G.CosmicUI_user_opts.rename.prompt + 1
   end
 
   popup_opts = utils.merge({

--- a/lua/cosmic-ui/rename/init.lua
+++ b/lua/cosmic-ui/rename/init.lua
@@ -10,8 +10,10 @@ local function rename(popup_opts, opts)
 
   local user_border = _G.CosmicUI_user_opts.rename.border
   local width = 25
-  if #curr_name > width then
-    width = #curr_name
+  if #curr_name + 3 > width then
+    -- consider border (+2) and on free space, otherwise the textbox scrolls
+    -- and shows an -- seemingly -- empty textbox
+    width = #curr_name + 3
   end
 
   popup_opts = utils.merge({


### PR DESCRIPTION
as the title says...

I tried to add an event handler that would change the size of the input again if the text changed, but I get an exception that says I'm not allowed to change the window size in the event handler.....

I though about setting the width to something like `#name` + 10 to have some space if the new identifier name is supposed to get longer. What do you think about it?