### PR TITLE
feat(codeactions): auto-apply lone code action

### DIFF
--- a/docs/codeactions.md
+++ b/docs/codeactions.md
@@ -19,6 +19,7 @@ require("cosmic-ui").setup({
 codeactions = {
   enabled = true,
   min_width = nil,
+  auto_apply_if_single = false,
   border = {
     bottom_hl = "FloatBorder",
     highlight = "FloatBorder",
@@ -54,6 +55,7 @@ Behavior:
 - warns and no-ops if `codeactions` is disabled
 - executes code action requests via the internal `cosmic-ui.codeactions` implementation
 - opens a native floating menu (no NUI dependency)
+- when `auto_apply_if_single = true`, auto-executes without opening the menu if exactly one action is available
 - menu groups are ordered deterministically by client name (tie-break: client id)
 - actions within each client group keep server response order
 - group headers are centered and rendered as bordered divider lines

--- a/docs/cosmic-ui.md
+++ b/docs/cosmic-ui.md
@@ -20,6 +20,7 @@ Initializes cosmic-ui config state and stores merged module options.
 | `rename.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for rename module. |
 | `codeactions` | `table\|nil` | No | disabled if omitted | Codeactions module config; set table to enable module. |
 | `codeactions.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for codeactions module. |
+| `codeactions.auto_apply_if_single` | `boolean\|nil` | No | `false` | Auto-execute when exactly one code action is available. |
 | `formatters` | `table\|nil` | No | disabled if omitted | Formatters module config; set table to enable module. |
 | `formatters.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for formatters module. |
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -74,6 +74,7 @@ Behavior:
 - Else if `opts.params` is present, `opts.params` is used directly.
 - Else cursor-based range params are created automatically.
 - Uses a native floating menu UI.
+- Can auto-apply a lone action when `codeactions.auto_apply_if_single = true`.
 - Code action menu groups are ordered deterministically by client name (tie-break: client id).
 - Action order within each client group follows server response order.
 

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -66,6 +66,11 @@ M.open = function(results_lsp, user_opts)
     return
   end
 
+  if user_opts.auto_apply_if_single and #built.actions == 1 then
+    submit_action(built.actions[1])
+    return
+  end
+
   local border = user_opts.border or {}
   local border_style = border.style or vim.o.winborder
   if border_style == '' then

--- a/lua/cosmic-ui/config.lua
+++ b/lua/cosmic-ui/config.lua
@@ -14,6 +14,7 @@ local defaults = {
   },
   codeactions = {
     min_width = nil,
+    auto_apply_if_single = false,
     border = {
       bottom_hl = 'FloatBorder',
       highlight = 'FloatBorder',

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ You may override any of the settings below by passing a config object to `.setup
   codeactions = {
     enabled = true, -- optional (defaults to true when table exists)
     min_width = nil,
+    auto_apply_if_single = false, -- auto-execute when only one action is available
     border = {
       bottom_hl = 'FloatBorder',
       highlight = 'FloatBorder',


### PR DESCRIPTION
## Summary
- add `codeactions.auto_apply_if_single` config (default `false`)
- auto-execute instead of rendering the code action menu when exactly one action is returned
- document the new option in README and docs

## Why
When only one code action is available, opening the picker adds extra keystrokes without adding choice. This option streamlines common quick-fix workflows while preserving existing behavior by default.

## Testing
- verified code changes compile logically in plugin modules
- attempted formatting check (`stylua --check`) but stylua is not installed in this environment
