### PR TITLE
feat: add diagnostics picker module

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,9 @@ This directory documents each Lua module in `lua/cosmic-ui`.
 - [`docs/cosmic-ui.md`](docs/cosmic-ui.md) - root module and lazy module loading
 - [`docs/config.md`](docs/config.md) - setup/config state and module gating
 - [`docs/utils.md`](docs/utils.md) - shared helpers and logger
-- [`docs/features.md`](docs/features.md) - combined docs for rename, codeactions, and formatters
+- [`docs/features.md`](docs/features.md) - combined docs for rename, codeactions, formatters, and diagnostics
 - [`docs/rename-handler.md`](docs/rename-handler.md) - LSP rename response handler
 - [`docs/rename.md`](docs/rename.md) - rename module API
 - [`docs/codeactions.md`](docs/codeactions.md) - code actions module API
 - [`docs/formatters.md`](docs/formatters.md) - formatters module API
+- [`docs/diagnostics.md`](docs/diagnostics.md) - diagnostics picker/location-list API

--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,7 @@ config.setup({
   rename = { enabled = true },
   codeactions = { enabled = true },
   formatters = { enabled = true },
+  diagnostics = { enabled = true },
 })
 ```
 

--- a/docs/cosmic-ui.md
+++ b/docs/cosmic-ui.md
@@ -3,7 +3,7 @@
 ## Intent
 
 Root plugin module that users require (`require("cosmic-ui")`).
-It stores setup state indirectly via `cosmic-ui.config` and lazily loads feature modules (`rename`, `codeactions`, `formatters`) on first access.
+It stores setup state indirectly via `cosmic-ui.config` and lazily loads feature modules (`rename`, `codeactions`, `formatters`, `diagnostics`) on first access.
 
 ## Exposed API
 
@@ -22,9 +22,11 @@ Initializes cosmic-ui config state and stores merged module options.
 | `codeactions.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for codeactions module. |
 | `formatters` | `table\|nil` | No | disabled if omitted | Formatters module config; set table to enable module. |
 | `formatters.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for formatters module. |
+| `diagnostics` | `table\|nil` | No | disabled if omitted | Diagnostics module config; set table to enable module. |
+| `diagnostics.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for diagnostics module. |
 
 Module enable semantics:
-- Missing module key (`rename`, `codeactions`, `formatters`) means disabled.
+- Missing module key (`rename`, `codeactions`, `formatters`, `diagnostics`) means disabled.
 - `enabled = false` inside a module table disables that module.
 
 ### `is_setup() -> boolean`
@@ -43,6 +45,10 @@ Lazy-loaded proxy to `require("cosmic-ui").codeactions` module methods.
 
 Lazy-loaded proxy to `require("cosmic-ui").formatters` module methods.
 
+### `diagnostics`
+
+Lazy-loaded proxy to `require("cosmic-ui").diagnostics` module methods.
+
 ## Usage
 
 ```lua
@@ -52,6 +58,7 @@ CosmicUI.setup({
   rename = {},
   codeactions = {},
   formatters = {},
+  diagnostics = {},
 })
 ```
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,80 @@
+# diagnostics
+
+Diagnostics module for `cosmic-ui`.
+This module validates setup/module enable state and provides a diagnostics picker plus location-list export.
+
+## Setup
+
+```lua
+require("cosmic-ui").setup({
+  diagnostics = {
+    enabled = true,
+  },
+})
+```
+
+## ⚙️ Config
+
+```lua
+diagnostics = {
+  enabled = true,
+  scope = "buffer", -- "buffer" or "workspace"
+  max_items = 300,
+  min_width = nil,
+  border = {
+    highlight = "FloatBorder",
+    style = nil, -- falls back to vim.o.winborder
+    title = "Diagnostics",
+    title_align = "center",
+    title_hl = "FloatBorder",
+  },
+}
+```
+
+## Types
+
+### `opts`
+
+Optional diagnostics options used by `open()` and `setloclist()`.
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `scope` | `"buffer"\|"workspace"\|nil` | No | `diagnostics.scope` | Scope used to collect diagnostics. |
+| `bufnr` | `integer\|nil` | No | current buffer (`0`) | Buffer used when `scope = "buffer"`. |
+| `severity` | `integer\|"error"\|"warn"\|"info"\|"hint"\|nil` | No | `nil` | Optional severity filter. |
+| `max_items` | `integer\|nil` | No | `diagnostics.max_items` | Max diagnostics returned in one render/export. |
+
+## Module
+
+### `require("cosmic-ui").diagnostics.open(opts?)`
+
+Opens a floating diagnostics picker.
+
+Behavior:
+- warns and no-ops if `setup()` has not run
+- warns and no-ops if `diagnostics` is disabled
+- shows diagnostics sorted by severity, then location
+- supports `q`/`<Esc>` close, `r` refresh, `<CR>` jump to selected diagnostic
+
+```lua
+vim.keymap.set("n", "<leader>gd", function()
+  require("cosmic-ui").diagnostics.open()
+end, { silent = true, desc = "Diagnostics (buffer)" })
+```
+
+```lua
+require("cosmic-ui").diagnostics.open({
+  scope = "workspace",
+  severity = "error",
+})
+```
+
+### `require("cosmic-ui").diagnostics.setloclist(opts?)`
+
+Builds the window location list from diagnostics and opens it (`:lopen`) when items exist.
+
+```lua
+vim.keymap.set("n", "<leader>gD", function()
+  require("cosmic-ui").diagnostics.setloclist({ scope = "workspace" })
+end, { silent = true, desc = "Diagnostics to loclist" })
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
-# Rename, Codeactions, and Formatters
+# Rename, Codeactions, Formatters, and Diagnostics
 
-This file explains how to use the three feature modules exposed through `require("cosmic-ui")`.
+This file explains how to use the feature modules exposed through `require("cosmic-ui")`.
 
 ## Prerequisites
 
@@ -11,6 +11,7 @@ require("cosmic-ui").setup({
   rename = {},
   codeactions = {},
   formatters = {},
+  diagnostics = {},
 })
 ```
 
@@ -218,6 +219,7 @@ Returns:
   - `source` (effective source: `requested`, `specific`, `global`, `default`, `clamped`)
   - `configured_source` (pre-clamp source: `requested`, `specific`, `global`, `default`)
   - `uses_lsp` (`boolean`)
+
   - `eligible_clients` / `total_clients`
   - `reason` (for example: `conform unavailable`, `lsp backend disabled`, `no eligible lsp clients`)
 - Each `lsp_clients[]` entry includes `conform_fallback`:
@@ -336,3 +338,41 @@ require("conform").setup({
 Note:
 - This controls Conform formatting only.
 - LSP code actions on save (for example `source.fixAll.eslint`) are separate and must be configured independently.
+
+## Diagnostics
+
+Use when you want to quickly review and navigate diagnostics for the current buffer or entire workspace.
+
+### API: `require("cosmic-ui").diagnostics.open(opts?)`
+
+Opens a floating diagnostics picker.
+
+`opts` definition:
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `opts` | `table\|nil` | No | `{}` | Optional diagnostics query options. |
+| `opts.scope` | `"buffer"\|"workspace"\|nil` | No | from `diagnostics.scope` config (`"buffer"`) | Scope to query diagnostics from. |
+| `opts.bufnr` | `integer\|nil` | No | current buffer (`0`) | Buffer queried when `scope = "buffer"`. |
+| `opts.severity` | `integer\|"error"\|"warn"\|"info"\|"hint"\|nil` | No | `nil` | Optional severity filter. |
+| `opts.max_items` | `integer\|nil` | No | from `diagnostics.max_items` config | Max diagnostics rendered. |
+
+Behavior:
+- Uses sorted diagnostics (severity then location).
+- Keymaps in picker: `q`/`<Esc>` close, `r` refresh, `<CR>` jump.
+
+### API: `require("cosmic-ui").diagnostics.setloclist(opts?)`
+
+Builds current window location-list entries from diagnostics and opens `:lopen` when entries exist.
+
+### Usage examples
+
+```lua
+vim.keymap.set("n", "<leader>gd", function()
+  require("cosmic-ui").diagnostics.open()
+end, { silent = true, desc = "Diagnostics" })
+
+vim.keymap.set("n", "<leader>gD", function()
+  require("cosmic-ui").diagnostics.setloclist({ scope = "workspace" })
+end, { silent = true, desc = "Diagnostics loclist" })
+```

--- a/lua/cosmic-ui/config.lua
+++ b/lua/cosmic-ui/config.lua
@@ -23,6 +23,17 @@ local defaults = {
     },
   },
   formatters = {},
+  diagnostics = {
+    scope = 'buffer',
+    max_items = 300,
+    min_width = nil,
+    border = {
+      highlight = 'FloatBorder',
+      title = 'Diagnostics',
+      title_align = 'center',
+      title_hl = 'FloatBorder',
+    },
+  },
 }
 
 local known_top_level_keys = {
@@ -30,6 +41,7 @@ local known_top_level_keys = {
   rename = true,
   codeactions = true,
   formatters = true,
+  diagnostics = true,
 }
 
 local state = {
@@ -76,6 +88,7 @@ M.setup = function(user_opts)
     rename = defaults.rename,
     codeactions = defaults.codeactions,
     formatters = defaults.formatters,
+    diagnostics = defaults.diagnostics,
   }) do
     local module_user_opts = user_opts[module_name]
     if type(module_user_opts) == 'table' then

--- a/lua/cosmic-ui/diagnostics/init.lua
+++ b/lua/cosmic-ui/diagnostics/init.lua
@@ -1,0 +1,343 @@
+local config = require('cosmic-ui.config')
+local guard = require('cosmic-ui.guard')
+local utils = require('cosmic-ui.utils')
+local window = require('cosmic-ui.window')
+local logger = utils.Logger
+
+local M = {}
+
+local severity_name_to_value = {
+  error = vim.diagnostic.severity.ERROR,
+  warn = vim.diagnostic.severity.WARN,
+  warning = vim.diagnostic.severity.WARN,
+  info = vim.diagnostic.severity.INFO,
+  hint = vim.diagnostic.severity.HINT,
+}
+
+local severity_value_to_prefix = {
+  [vim.diagnostic.severity.ERROR] = 'E',
+  [vim.diagnostic.severity.WARN] = 'W',
+  [vim.diagnostic.severity.INFO] = 'I',
+  [vim.diagnostic.severity.HINT] = 'H',
+}
+
+local severity_value_to_loclist_type = {
+  [vim.diagnostic.severity.ERROR] = 'E',
+  [vim.diagnostic.severity.WARN] = 'W',
+  [vim.diagnostic.severity.INFO] = 'I',
+  [vim.diagnostic.severity.HINT] = 'I',
+}
+
+local function normalize_severity(severity)
+  if severity == nil then
+    return nil
+  end
+
+  if type(severity) == 'number' then
+    return severity
+  end
+
+  if type(severity) ~= 'string' then
+    return nil
+  end
+
+  return severity_name_to_value[string.lower(severity)]
+end
+
+local function normalize_scope(scope)
+  if scope == nil then
+    return 'buffer'
+  end
+
+  if scope == 'buffer' or scope == 'workspace' then
+    return scope
+  end
+
+  return nil
+end
+
+local function resolve_bufnr(bufnr)
+  local resolved = bufnr
+  if resolved == nil then
+    resolved = 0
+  end
+
+  if resolved == 0 then
+    resolved = vim.api.nvim_get_current_buf()
+  end
+
+  if type(resolved) ~= 'number' or resolved < 1 or not vim.api.nvim_buf_is_valid(resolved) then
+    return nil
+  end
+
+  return resolved
+end
+
+local function sanitize_message(message)
+  return (message or ''):gsub('\r', ' '):gsub('\n', ' '):gsub('%s+', ' ')
+end
+
+local function diagnostics_title(opts, total_count)
+  local scope_label = opts.scope == 'workspace' and 'workspace' or 'buffer'
+  local severity_label = ''
+  if opts.severity ~= nil then
+    severity_label = (' severity=%s'):format(severity_value_to_prefix[opts.severity] or tostring(opts.severity))
+  end
+
+  return ('Diagnostics [%s]%s (%d)'):format(scope_label, severity_label, total_count)
+end
+
+local function relative_or_tail_path(bufnr)
+  local path = vim.api.nvim_buf_get_name(bufnr)
+  if path == nil or path == '' then
+    return '[No Name]'
+  end
+
+  local relative = vim.fn.fnamemodify(path, ':.')
+  if relative == '' or relative == '.' then
+    return vim.fn.fnamemodify(path, ':t')
+  end
+
+  return relative
+end
+
+local function collect(opts)
+  local severity = normalize_severity(opts.severity)
+  if opts.severity ~= nil and severity == nil then
+    logger:warn('Invalid diagnostics severity; expected number or one of: error, warn, info, hint')
+    return {}
+  end
+
+  local diagnostics
+  if opts.scope == 'workspace' then
+    diagnostics = vim.diagnostic.get(nil, { severity = severity })
+  else
+    diagnostics = vim.diagnostic.get(opts.bufnr, { severity = severity })
+  end
+
+  table.sort(diagnostics, function(a, b)
+    if a.severity ~= b.severity then
+      return a.severity < b.severity
+    end
+    if a.bufnr ~= b.bufnr then
+      return a.bufnr < b.bufnr
+    end
+    if a.lnum ~= b.lnum then
+      return a.lnum < b.lnum
+    end
+    return a.col < b.col
+  end)
+
+  local max_items = tonumber(opts.max_items) or #diagnostics
+  if max_items > 0 and #diagnostics > max_items then
+    diagnostics = vim.list_slice(diagnostics, 1, max_items)
+  end
+
+  return diagnostics
+end
+
+local function format_line(item)
+  local prefix = severity_value_to_prefix[item.severity] or '?'
+  local path = relative_or_tail_path(item.bufnr)
+  local source = item.source and item.source ~= '' and (' [%s]'):format(item.source) or ''
+  return ('%s %s:%d:%d %s%s'):format(
+    prefix,
+    path,
+    item.lnum + 1,
+    item.col + 1,
+    sanitize_message(item.message),
+    source
+  )
+end
+
+local function jump_to(item)
+  if not (item and item.bufnr and vim.api.nvim_buf_is_valid(item.bufnr)) then
+    return
+  end
+
+  vim.api.nvim_set_current_buf(item.bufnr)
+  vim.api.nvim_win_set_cursor(0, { item.lnum + 1, item.col })
+  vim.cmd('normal! zz')
+end
+
+local function resolve_open_opts(user_opts)
+  local module_opts = config.module_opts('diagnostics') or {}
+  local opts = utils.merge({
+    scope = module_opts.scope,
+    severity = nil,
+    bufnr = 0,
+    max_items = module_opts.max_items,
+  }, user_opts or {})
+
+  local scope = normalize_scope(opts.scope)
+  if not scope then
+    logger:warn('diagnostics.open: `scope` must be "buffer" or "workspace"')
+    return nil
+  end
+
+  opts.scope = scope
+  opts.bufnr = resolve_bufnr(opts.bufnr)
+  if opts.scope == 'buffer' and not opts.bufnr then
+    logger:warn('diagnostics.open: invalid buffer')
+    return nil
+  end
+
+  return opts
+end
+
+local function open_picker(opts)
+  local module_opts = config.module_opts('diagnostics') or {}
+  local border_opts = module_opts.border or {}
+  local diagnostics = collect(opts)
+
+  if #diagnostics == 0 then
+    logger:log('No diagnostics found for current selection.')
+    return
+  end
+
+  local lines = {
+    diagnostics_title(opts, #diagnostics),
+    'Enter: jump  r: refresh  q/Esc: close',
+  }
+
+  local line_to_item = {}
+  for index, item in ipairs(diagnostics) do
+    lines[#lines + 1] = format_line(item)
+    line_to_item[index + 2] = item
+  end
+
+  local max_line_width = 0
+  for _, line in ipairs(lines) do
+    max_line_width = math.max(max_line_width, vim.fn.strdisplaywidth(line))
+  end
+
+  local configured_min_width = tonumber(module_opts.min_width)
+  local width = max_line_width + 2
+  if configured_min_width and configured_min_width > width then
+    width = configured_min_width
+  end
+
+  local height = math.max(4, math.min(#lines, math.floor((vim.o.lines - vim.o.cmdheight) * 0.7)))
+  local float_config = window.centered_float_config(width, height, {
+    max_height = math.max(10, math.floor((vim.o.lines - vim.o.cmdheight) * 0.8)),
+  })
+
+  local buf = window.create_scratch_buf({ modifiable = true, filetype = 'cosmicui-diagnostics' })
+  if not buf then
+    logger:error('Unable to open diagnostics window')
+    return
+  end
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+
+  local win = window.open_float(buf, {
+    border = {
+      border_opts.style or vim.o.winborder,
+      border_opts.highlight,
+    },
+    title = border_opts.title or 'Diagnostics',
+    title_pos = border_opts.title_align or 'center',
+    width = float_config.width,
+    height = float_config.height,
+    row = float_config.row,
+    col = float_config.col,
+  })
+
+  vim.wo[win].cursorline = true
+  vim.wo[win].wrap = false
+  vim.wo[win].number = false
+  vim.wo[win].relativenumber = false
+  vim.wo[win].signcolumn = 'no'
+
+  local function close_picker()
+    window.safe_close_win(win)
+    window.safe_delete_buf(buf)
+  end
+
+  local function refresh_picker()
+    close_picker()
+    vim.schedule(function()
+      M.open(opts)
+    end)
+  end
+
+  local function jump_selected()
+    local row = vim.api.nvim_win_get_cursor(win)[1]
+    local item = line_to_item[row]
+    if not item then
+      return
+    end
+
+    close_picker()
+    vim.schedule(function()
+      jump_to(item)
+    end)
+  end
+
+  vim.keymap.set('n', '<Esc>', close_picker, { buffer = buf, silent = true, nowait = true })
+  vim.keymap.set('n', 'q', close_picker, { buffer = buf, silent = true, nowait = true })
+  vim.keymap.set('n', 'r', refresh_picker, { buffer = buf, silent = true, nowait = true })
+  vim.keymap.set('n', '<CR>', jump_selected, { buffer = buf, silent = true, nowait = true })
+
+  vim.api.nvim_win_set_cursor(win, { math.min(3, #lines), 0 })
+end
+
+M.open = function(opts)
+  if not guard.can_run('diagnostics', 'diagnostics.open(...)') then
+    return
+  end
+
+  if opts ~= nil and type(opts) ~= 'table' then
+    error('diagnostics.open: invalid arguments')
+  end
+
+  local resolved_opts = resolve_open_opts(opts)
+  if not resolved_opts then
+    return
+  end
+
+  open_picker(resolved_opts)
+end
+
+M.setloclist = function(opts)
+  if not guard.can_run('diagnostics', 'diagnostics.setloclist(...)') then
+    return
+  end
+
+  if opts ~= nil and type(opts) ~= 'table' then
+    error('diagnostics.setloclist: invalid arguments')
+  end
+
+  local resolved_opts = resolve_open_opts(opts)
+  if not resolved_opts then
+    return
+  end
+
+  local diagnostics = collect(resolved_opts)
+  local items = {}
+  for _, item in ipairs(diagnostics) do
+    items[#items + 1] = {
+      bufnr = item.bufnr,
+      lnum = item.lnum + 1,
+      col = item.col + 1,
+      text = sanitize_message(item.message),
+      type = severity_value_to_loclist_type[item.severity] or 'I',
+    }
+  end
+
+  vim.fn.setloclist(0, {}, ' ', {
+    title = diagnostics_title(resolved_opts, #items),
+    items = items,
+  })
+
+  if #items == 0 then
+    logger:log('Location list cleared: no diagnostics found for current selection.')
+    return
+  end
+
+  vim.cmd('lopen')
+  logger:log(('Loaded %d diagnostics into location list.'):format(#items))
+end
+
+return M

--- a/lua/cosmic-ui/init.lua
+++ b/lua/cosmic-ui/init.lua
@@ -4,6 +4,7 @@ local module_map = {
   rename = 'cosmic-ui.rename',
   codeactions = 'cosmic-ui.codeactions',
   formatters = 'cosmic-ui.formatters',
+  diagnostics = 'cosmic-ui.diagnostics',
 }
 
 local M = {

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ Cosmic-UI is a simple wrapper around specific vim functionality. Built in order 
 - Rename floating popup & file change notification
 - Code Actions
 - Formatter toggles (LSP + Conform.nvim)
+- Diagnostics picker + location-list export
 
 ## 📷 Screenshots
 
@@ -84,6 +85,20 @@ You may override any of the settings below by passing a config object to `.setup
   formatters = {
     enabled = true, -- optional (defaults to true when table exists)
   },
+
+  diagnostics = {
+    enabled = true, -- optional (defaults to true when table exists)
+    scope = "buffer", -- "buffer" or "workspace"
+    max_items = 300,
+    min_width = nil,
+    border = {
+      highlight = "FloatBorder",
+      style = nil, -- falls back to vim.o.winborder
+      title = "Diagnostics",
+      title_align = "center",
+      title_hl = "FloatBorder",
+    },
+  },
 }
 ```
 
@@ -103,6 +118,8 @@ Notes:
   Docs: [`docs/codeactions.md`](docs/codeactions.md)
 - `formatters`: Toggle and run Conform/LSP formatting with buffer/global scope control and per-item overrides.  
   Docs: [`docs/formatters.md`](docs/formatters.md)
+- `diagnostics`: Open a floating diagnostics picker and export diagnostics to the location list.  
+  Docs: [`docs/diagnostics.md`](docs/diagnostics.md)
 
 ### Core modules
 
@@ -121,6 +138,7 @@ CosmicUI.setup({
   rename = {},
   codeactions = {},
   formatters = {},
+  diagnostics = {},
 })
 ```
 
@@ -160,6 +178,18 @@ vim.keymap.set("n", "<leader>fm", function()
 end, { silent = true, desc = "Format buffer" })
 ```
 
+### Diagnostics
+
+```lua
+vim.keymap.set("n", "<leader>gd", function()
+  require("cosmic-ui").diagnostics.open()
+end, { silent = true, desc = "Diagnostics (buffer)" })
+
+vim.keymap.set("n", "<leader>gD", function()
+  require("cosmic-ui").diagnostics.setloclist({ scope = "workspace" })
+end, { silent = true, desc = "Diagnostics to loclist" })
+```
+
 Formatting behavior:
 - If Conform.nvim is installed and conform backend is enabled, `format()` uses Conform.
 - If Conform.nvim is unavailable (or conform backend is disabled), `format()` falls back to LSP when LSP backend is enabled.
@@ -172,3 +202,4 @@ More usage examples:
 - Rename: [`docs/rename.md`](docs/rename.md)
 - Codeactions: [`docs/codeactions.md`](docs/codeactions.md)
 - Formatters: [`docs/formatters.md`](docs/formatters.md)
+- Diagnostics: [`docs/diagnostics.md`](docs/diagnostics.md)


### PR DESCRIPTION
## Summary
- add a new `diagnostics` feature module for CosmicUI
- provide `diagnostics.open()` floating picker for buffer/workspace diagnostics
- provide `diagnostics.setloclist()` to export diagnostics into location list
- wire module into setup/config/lazy loading and document it across README/docs

## Validation
- `nvim --headless -u NONE '+set rtp+=.' '+lua local c=require("cosmic-ui"); c.setup({diagnostics={}}); c.diagnostics.setloclist(); print("diagnostics-setloclist-ok")' '+qa'`
  - noted non-blocking local ShaDa permission warning in this sandbox
