### PR TITLE
feat(codeactions): repeat last action in current context

### DIFF
--- a/docs/codeactions.md
+++ b/docs/codeactions.md
@@ -91,3 +91,26 @@ require("cosmic-ui").codeactions.range({
   range = { start = { 10, 0 }, ["end"] = { 12, 0 } },
 })
 ```
+
+### `require("cosmic-ui").codeactions.repeat_last(opts?)`
+
+Requests code actions for the current context and re-executes the last action selected through CosmicUI.
+
+Behavior:
+- warns and no-ops if `setup()` has not run or module is disabled
+- warns when there is no previously selected code action to repeat
+- uses request precedence `opts.range` > `opts.params` > cursor range
+- matches by action `title` + `kind`, preferring the same client when available
+- warns when the previous action does not exist in the current context
+
+```lua
+vim.keymap.set("n", "<leader>gA", function()
+  require("cosmic-ui").codeactions.repeat_last()
+end)
+```
+
+```lua
+require("cosmic-ui").codeactions.repeat_last({
+  params = { context = { only = { "quickfix" } } },
+})
+```

--- a/docs/cosmic-ui.md
+++ b/docs/cosmic-ui.md
@@ -58,5 +58,6 @@ CosmicUI.setup({
 ```lua
 if require("cosmic-ui").is_setup() then
   require("cosmic-ui").codeactions.open()
+  require("cosmic-ui").codeactions.repeat_last()
 end
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -94,6 +94,23 @@ Behavior:
 - Else uses `opts.params` when provided.
 - Else builds `range` from `'<` and `'>` marks.
 
+### API: `require("cosmic-ui").codeactions.repeat_last(opts?)`
+
+Re-runs the last code action you applied through CosmicUI in the current context.
+
+`opts` definition:
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `opts` | `table\|nil` | No | `{}` | Optional code action request input. |
+| `opts.params` | `table\|nil` | No | `nil` | Optional explicit params override. |
+| `opts.range` | `table\|nil` | No | `nil` | Optional range override. |
+
+Behavior:
+- Uses the same request precedence as `open` (`range` > `params` > cursor range).
+- Matches by action title + kind, preferring the same LSP client when available.
+- Warns if no previous action exists or no matching action is available in the current context.
+
 ### Usage examples
 
 ```lua
@@ -104,6 +121,10 @@ end, { silent = true, desc = "Code actions" })
 vim.keymap.set("v", "<leader>ga", function()
   require("cosmic-ui").codeactions.range()
 end, { silent = true, desc = "Range code actions" })
+
+vim.keymap.set("n", "<leader>gA", function()
+  require("cosmic-ui").codeactions.repeat_last()
+end, { silent = true, desc = "Repeat last code action" })
 ```
 
 ### Optional advanced opts

--- a/lua/cosmic-ui/codeactions/execute.lua
+++ b/lua/cosmic-ui/codeactions/execute.lua
@@ -1,0 +1,48 @@
+local utils = require('cosmic-ui.utils')
+local transform = require('cosmic-ui.codeactions.transform')
+local logger = utils.Logger
+
+local M = {}
+
+M.run = function(action, on_executed)
+  local client = action.client
+  local command = action.command
+
+  if not client then
+    logger:warn('Code action client is no longer available')
+    return false
+  end
+
+  local function after_execute(final_command)
+    if on_executed then
+      on_executed({
+        client = client,
+        command = final_command,
+        title = action.title or final_command.title,
+        kind = action.kind or final_command.kind,
+      })
+    end
+    return true
+  end
+
+  if not command.edit and transform.supports_code_action_resolve(client) then
+    client:request('codeAction/resolve', command, function(resolved_err, resolved_action)
+      if resolved_err then
+        local code = resolved_err.code or 'unknown'
+        local msg = resolved_err.message or vim.inspect(resolved_err)
+        logger:error(code .. ': ' .. msg)
+        return
+      end
+
+      local final_action = resolved_action or command
+      transform.execute_action(transform.transform_action(final_action), client)
+      after_execute(final_action)
+    end)
+    return true
+  end
+
+  transform.execute_action(transform.transform_action(command), client)
+  return after_execute(command)
+end
+
+return M

--- a/lua/cosmic-ui/codeactions/init.lua
+++ b/lua/cosmic-ui/codeactions/init.lua
@@ -2,20 +2,75 @@ local utils = require('cosmic-ui.utils')
 local config = require('cosmic-ui.config')
 local guard = require('cosmic-ui.guard')
 local request = require('cosmic-ui.codeactions.request')
+local execute = require('cosmic-ui.codeactions.execute')
 local ui = require('cosmic-ui.codeactions.ui')
+local model = require('cosmic-ui.codeactions.ui.model')
 local logger = utils.Logger
 
 local M = {}
+local state = {
+  last_action = nil,
+}
 
-local function run_code_actions(opts)
-  local bufnr = 0
+local function remember_last_action(executed)
+  local client = executed.client
+  state.last_action = {
+    title = executed.title or '',
+    action_kind = executed.kind,
+    client_name = client and client.name or nil,
+  }
+end
+
+local function find_matching_action(actions, previous)
+  local function action_matches(action, require_client_name)
+    if action.title ~= previous.title then
+      return false
+    end
+
+    if action.action_kind ~= previous.action_kind then
+      return false
+    end
+
+    if not require_client_name then
+      return true
+    end
+
+    local action_client_name = action.client and action.client.name or nil
+    return action_client_name == previous.client_name
+  end
+
+  for _, action in ipairs(actions) do
+    if action_matches(action, true) then
+      return action
+    end
+  end
+
+  for _, action in ipairs(actions) do
+    if action_matches(action, false) then
+      return action
+    end
+  end
+
+  return nil
+end
+
+local function get_codeaction_clients(bufnr)
   local clients = vim.lsp.get_clients({ bufnr = bufnr, method = 'textDocument/codeAction' })
   if #clients == 0 then
     logger:warn('No LSP clients with code actions attached')
+    return nil
+  end
+  return clients
+end
+
+local function run_code_actions(opts)
+  local bufnr = 0
+  local clients = get_codeaction_clients(bufnr)
+  if not clients then
     return
   end
 
-  opts = utils.merge({ params = nil, range = nil }, opts or {})
+  opts = utils.merge({ params = nil, range = nil, on_action_executed = nil }, opts or {})
   local user_opts = config.module_opts('codeactions') or {}
 
   request.collect({
@@ -23,7 +78,9 @@ local function run_code_actions(opts)
     clients = clients,
     user_opts = opts,
     on_complete = function(results_lsp)
-      ui.open(results_lsp, user_opts)
+      ui.open(results_lsp, utils.merge(user_opts, {
+        on_action_executed = opts.on_action_executed,
+      }))
     end,
   })
 end
@@ -33,6 +90,8 @@ M.open = function(opts)
     return
   end
 
+  opts = opts or {}
+  opts.on_action_executed = remember_last_action
   return run_code_actions(opts)
 end
 
@@ -54,7 +113,49 @@ M.range = function(opts)
     }, opts)
   end
 
+  opts.on_action_executed = remember_last_action
   return run_code_actions(opts)
+end
+
+M.repeat_last = function(opts)
+  if not guard.can_run('codeactions', 'codeactions.repeat_last(...)') then
+    return
+  end
+
+  local previous = state.last_action
+  if not previous then
+    logger:warn('No previous code action to repeat')
+    return
+  end
+
+  local bufnr = 0
+  local clients = get_codeaction_clients(bufnr)
+  if not clients then
+    return
+  end
+
+  opts = utils.merge({ params = nil, range = nil }, opts or {})
+
+  request.collect({
+    bufnr = bufnr,
+    clients = clients,
+    user_opts = opts,
+    on_complete = function(results_lsp)
+      local built = model.build(results_lsp)
+      if #built.actions == 0 then
+        logger:log('No code actions available')
+        return
+      end
+
+      local matched = find_matching_action(built.actions, previous)
+      if not matched then
+        logger:warn('No matching code action found for "' .. previous.title .. '" in current context')
+        return
+      end
+
+      execute.run(matched, remember_last_action)
+    end,
+  })
 end
 
 return M

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -1,6 +1,6 @@
 local utils = require('cosmic-ui.utils')
 local window = require('cosmic-ui.window')
-local transform = require('cosmic-ui.codeactions.transform')
+local execute = require('cosmic-ui.codeactions.execute')
 local lifecycle = require('cosmic-ui.codeactions.ui.lifecycle')
 local model = require('cosmic-ui.codeactions.ui.model')
 local render = require('cosmic-ui.codeactions.ui.render')
@@ -20,36 +20,6 @@ end
 local function compute_height(row_count)
   local max_height = math.max(8, math.floor((vim.o.lines - vim.o.cmdheight) * 0.7))
   return math.max(1, math.min(row_count, max_height))
-end
-
-local function submit_action(action)
-  local client = action.client
-  local command = action.command
-
-  if not client then
-    logger:warn('Code action client is no longer available')
-    return
-  end
-
-  if not command.edit and transform.supports_code_action_resolve(client) then
-    client:request('codeAction/resolve', command, function(resolved_err, resolved_action)
-      if resolved_err then
-        local code = resolved_err.code or 'unknown'
-        local msg = resolved_err.message or vim.inspect(resolved_err)
-        logger:error(code .. ': ' .. msg)
-        return
-      end
-
-      if resolved_action then
-        transform.execute_action(transform.transform_action(resolved_action), client)
-      else
-        transform.execute_action(transform.transform_action(command), client)
-      end
-    end)
-    return
-  end
-
-  transform.execute_action(transform.transform_action(command), client)
 end
 
 M.open = function(results_lsp, user_opts)
@@ -139,7 +109,9 @@ M.open = function(results_lsp, user_opts)
   lifecycle.set_ui(ui)
 
   local handlers = {
-    submit_action = submit_action,
+    submit_action = function(action)
+      return execute.run(action, user_opts.on_action_executed)
+    end,
   }
 
   local deps = {

--- a/lua/cosmic-ui/codeactions/ui/model.lua
+++ b/lua/cosmic-ui/codeactions/ui/model.lua
@@ -42,6 +42,8 @@ M.build = function(results_lsp)
         local action = {
           kind = 'action',
           text = command_title,
+          title = result.title or '',
+          action_kind = result.kind,
           client = client,
           command = result,
         }

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Notes:
 
 - `rename`: Cursor-local rename input that dispatches LSP rename requests.  
   Docs: [`docs/rename.md`](docs/rename.md)
-- `codeactions`: Aggregates LSP code actions for cursor/range and executes the selected action.  
+- `codeactions`: Aggregates LSP code actions for cursor/range, executes selections, and can repeat your last applied action.  
   Docs: [`docs/codeactions.md`](docs/codeactions.md)
 - `formatters`: Toggle and run Conform/LSP formatting with buffer/global scope control and per-item overrides.  
   Docs: [`docs/formatters.md`](docs/formatters.md)
@@ -142,6 +142,10 @@ end, { silent = true, desc = "Code actions" })
 vim.keymap.set("v", "<leader>ga", function()
   require("cosmic-ui").codeactions.range()
 end, { silent = true, desc = "Range code actions" })
+
+vim.keymap.set("n", "<leader>gA", function()
+  require("cosmic-ui").codeactions.repeat_last()
+end, { silent = true, desc = "Repeat last code action" })
 ```
 
 ### Formatters


### PR DESCRIPTION
## Summary
- add `codeactions.repeat_last(opts?)` to re-run the last code action picked through CosmicUI
- track last applied action metadata (title/kind/client) and resolve best current-context match
- extract shared code action execution path into `lua/cosmic-ui/codeactions/execute.lua` so normal selection and replay use identical resolve/execute behavior
- document new API and usage examples in README and module docs

## Validation
- `nvim --headless -u NONE +'set rtp+=.' +"lua local c=require('cosmic-ui'); c.setup({ codeactions = {} }); c.codeactions.open(); c.codeactions.repeat_last()" +qa`
- `stylua --check` not run (stylua is not installed in this environment)
