### PR TITLE
feat(codeactions): add preferred-action quick apply flow

### DIFF
--- a/docs/codeactions.md
+++ b/docs/codeactions.md
@@ -19,6 +19,7 @@ require("cosmic-ui").setup({
 codeactions = {
   enabled = true,
   min_width = nil,
+  auto_apply_preferred_if_single = false,
   border = {
     bottom_hl = "FloatBorder",
     highlight = "FloatBorder",
@@ -42,6 +43,7 @@ Optional request options passed to the code action core module.
 | `range` | `table\|nil` | No | `nil` | Optional range `{ start, end }`. |
 | `range.start` | `{integer, integer}\|nil` | No | `nil` | Optional start position `{line, col}`. |
 | `range.end` | `{integer, integer}\|nil` | No | `nil` | Optional end position `{line, col}`. |
+| `fallback_to_menu` | `boolean\|nil` | No | `true` | Used by `preferred()`: open picker when no unique preferred action exists. |
 
 ## Module
 
@@ -59,6 +61,7 @@ Behavior:
 - group headers are centered and rendered as bordered divider lines
 - selection index/count is shown in the float border footer (right-aligned)
 - keymaps: `j`/`k`, `<Down>`/`<Up>`, `<Tab>`/`<S-Tab>`, `<CR>`/`<Space>`, `<Esc>`/`<C-c>`
+- when `codeactions.auto_apply_preferred_if_single = true`, applies one preferred action immediately instead of opening menu
 
 ```lua
 require("cosmic-ui").codeactions.open()
@@ -90,4 +93,21 @@ end)
 require("cosmic-ui").codeactions.range({
   range = { start = { 10, 0 }, ["end"] = { 12, 0 } },
 })
+```
+
+### `require("cosmic-ui").codeactions.preferred(opts?)`
+
+Requests code actions at the current cursor context and applies a preferred action when there is exactly one preferred match.
+
+Behavior:
+- warns and no-ops if `setup()` has not run or module is disabled
+- applies the single preferred code action directly
+- if none/multiple preferred actions exist:
+  - opens the menu by default
+  - or only warns when `opts.fallback_to_menu = false`
+
+```lua
+vim.keymap.set("n", "<leader>gA", function()
+  require("cosmic-ui").codeactions.preferred()
+end)
 ```

--- a/docs/cosmic-ui.md
+++ b/docs/cosmic-ui.md
@@ -20,6 +20,7 @@ Initializes cosmic-ui config state and stores merged module options.
 | `rename.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for rename module. |
 | `codeactions` | `table\|nil` | No | disabled if omitted | Codeactions module config; set table to enable module. |
 | `codeactions.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for codeactions module. |
+| `codeactions.auto_apply_preferred_if_single` | `boolean\|nil` | No | `false` | Auto-apply a single preferred code action before opening the picker. |
 | `formatters` | `table\|nil` | No | disabled if omitted | Formatters module config; set table to enable module. |
 | `formatters.enabled` | `boolean\|nil` | No | `true` when table exists | Explicit enable/disable switch for formatters module. |
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -74,6 +74,7 @@ Behavior:
 - Else if `opts.params` is present, `opts.params` is used directly.
 - Else cursor-based range params are created automatically.
 - Uses a native floating menu UI.
+- If `codeactions.auto_apply_preferred_if_single = true`, one preferred action is auto-applied instead of opening the menu.
 - Code action menu groups are ordered deterministically by client name (tie-break: client id).
 - Action order within each client group follows server response order.
 
@@ -94,6 +95,25 @@ Behavior:
 - Else uses `opts.params` when provided.
 - Else builds `range` from `'<` and `'>` marks.
 
+### API: `require("cosmic-ui").codeactions.preferred(opts?)`
+
+Fetches code actions at cursor and applies the preferred action when exactly one preferred action exists.
+
+`opts` definition:
+
+| Field | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `opts` | `table\|nil` | No | `{}` | Optional code action request input. |
+| `opts.params` | `table\|nil` | No | `nil` | Optional explicit params override. |
+| `opts.range` | `table\|nil` | No | `nil` | Optional range override. |
+| `opts.fallback_to_menu` | `boolean\|nil` | No | `true` | Open menu when preferred action is missing/ambiguous. |
+
+Behavior:
+- If exactly one preferred action exists, it is applied immediately.
+- If zero or multiple preferred actions exist:
+  - menu opens by default
+  - warning-only when `fallback_to_menu = false`.
+
 ### Usage examples
 
 ```lua
@@ -104,6 +124,10 @@ end, { silent = true, desc = "Code actions" })
 vim.keymap.set("v", "<leader>ga", function()
   require("cosmic-ui").codeactions.range()
 end, { silent = true, desc = "Range code actions" })
+
+vim.keymap.set("n", "<leader>gA", function()
+  require("cosmic-ui").codeactions.preferred()
+end, { silent = true, desc = "Preferred code action" })
 ```
 
 ### Optional advanced opts

--- a/lua/cosmic-ui/codeactions/execute.lua
+++ b/lua/cosmic-ui/codeactions/execute.lua
@@ -1,0 +1,33 @@
+local transform = require('cosmic-ui.codeactions.transform')
+local utils = require('cosmic-ui.utils')
+local logger = utils.Logger
+
+local M = {}
+
+M.execute = function(action, client)
+  if not client then
+    logger:warn('Code action client is no longer available')
+    return false
+  end
+
+  if not action.edit and transform.supports_code_action_resolve(client) then
+    client:request('codeAction/resolve', action, function(resolved_err, resolved_action)
+      if resolved_err then
+        local code = resolved_err.code or 'unknown'
+        local msg = resolved_err.message or vim.inspect(resolved_err)
+        logger:error(code .. ': ' .. msg)
+        transform.execute_action(transform.transform_action(action), client)
+        return
+      end
+
+      local command = resolved_action or action
+      transform.execute_action(transform.transform_action(command), client)
+    end)
+    return true
+  end
+
+  transform.execute_action(transform.transform_action(action), client)
+  return true
+end
+
+return M

--- a/lua/cosmic-ui/codeactions/init.lua
+++ b/lua/cosmic-ui/codeactions/init.lua
@@ -2,12 +2,69 @@ local utils = require('cosmic-ui.utils')
 local config = require('cosmic-ui.config')
 local guard = require('cosmic-ui.guard')
 local request = require('cosmic-ui.codeactions.request')
+local execute = require('cosmic-ui.codeactions.execute')
 local ui = require('cosmic-ui.codeactions.ui')
 local logger = utils.Logger
 
 local M = {}
 
-local function run_code_actions(opts)
+local function collect_actions(results_lsp)
+  local actions = {}
+
+  for _, response in pairs(results_lsp or {}) do
+    if response.client and type(response.result) == 'table' then
+      for _, action in ipairs(response.result) do
+        table.insert(actions, {
+          client = response.client,
+          command = action,
+        })
+      end
+    end
+  end
+
+  return actions
+end
+
+local function select_preferred(actions)
+  local preferred = {}
+  for _, action in ipairs(actions) do
+    if action.command and action.command.isPreferred == true then
+      table.insert(preferred, action)
+    end
+  end
+
+  if #preferred == 1 then
+    return preferred[1], 'single'
+  end
+
+  if #preferred == 0 then
+    return nil, 'none'
+  end
+
+  return nil, 'multiple'
+end
+
+local function apply_preferred(results_lsp, warn_on_failure)
+  local actions = collect_actions(results_lsp)
+  local selected, reason = select_preferred(actions)
+  if selected then
+    execute.execute(selected.command, selected.client)
+    logger:log(('Applied preferred code action: %s'):format(selected.command.title or ''))
+    return true
+  end
+
+  if warn_on_failure then
+    if reason == 'none' then
+      logger:warn('No preferred code action available in this context')
+    else
+      logger:warn('Multiple preferred code actions available; open menu to choose one')
+    end
+  end
+
+  return false
+end
+
+local function run_code_actions(opts, mode)
   local bufnr = 0
   local clients = vim.lsp.get_clients({ bufnr = bufnr, method = 'textDocument/codeAction' })
   if #clients == 0 then
@@ -15,15 +72,33 @@ local function run_code_actions(opts)
     return
   end
 
-  opts = utils.merge({ params = nil, range = nil }, opts or {})
-  local user_opts = config.module_opts('codeactions') or {}
+  local request_opts = utils.merge({
+    params = nil,
+    range = nil,
+    fallback_to_menu = true,
+  }, opts or {})
+  local module_opts = config.module_opts('codeactions') or {}
 
   request.collect({
     bufnr = bufnr,
     clients = clients,
-    user_opts = opts,
+    user_opts = request_opts,
     on_complete = function(results_lsp)
-      ui.open(results_lsp, user_opts)
+      if mode == 'preferred' then
+        if apply_preferred(results_lsp, request_opts.fallback_to_menu == false) then
+          return
+        end
+
+        if request_opts.fallback_to_menu == false then
+          return
+        end
+      elseif module_opts.auto_apply_preferred_if_single then
+        if apply_preferred(results_lsp, false) then
+          return
+        end
+      end
+
+      ui.open(results_lsp, module_opts)
     end,
   })
 end
@@ -33,7 +108,7 @@ M.open = function(opts)
     return
   end
 
-  return run_code_actions(opts)
+  return run_code_actions(opts, 'menu')
 end
 
 M.range = function(opts)
@@ -54,7 +129,15 @@ M.range = function(opts)
     }, opts)
   end
 
-  return run_code_actions(opts)
+  return run_code_actions(opts, 'menu')
+end
+
+M.preferred = function(opts)
+  if not guard.can_run('codeactions', 'codeactions.preferred(...)') then
+    return
+  end
+
+  return run_code_actions(opts, 'preferred')
 end
 
 return M

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -1,6 +1,6 @@
 local utils = require('cosmic-ui.utils')
 local window = require('cosmic-ui.window')
-local transform = require('cosmic-ui.codeactions.transform')
+local execute = require('cosmic-ui.codeactions.execute')
 local lifecycle = require('cosmic-ui.codeactions.ui.lifecycle')
 local model = require('cosmic-ui.codeactions.ui.model')
 local render = require('cosmic-ui.codeactions.ui.render')
@@ -23,33 +23,7 @@ local function compute_height(row_count)
 end
 
 local function submit_action(action)
-  local client = action.client
-  local command = action.command
-
-  if not client then
-    logger:warn('Code action client is no longer available')
-    return
-  end
-
-  if not command.edit and transform.supports_code_action_resolve(client) then
-    client:request('codeAction/resolve', command, function(resolved_err, resolved_action)
-      if resolved_err then
-        local code = resolved_err.code or 'unknown'
-        local msg = resolved_err.message or vim.inspect(resolved_err)
-        logger:error(code .. ': ' .. msg)
-        return
-      end
-
-      if resolved_action then
-        transform.execute_action(transform.transform_action(resolved_action), client)
-      else
-        transform.execute_action(transform.transform_action(command), client)
-      end
-    end)
-    return
-  end
-
-  transform.execute_action(transform.transform_action(command), client)
+  execute.execute(action.command, action.client)
 end
 
 M.open = function(results_lsp, user_opts)

--- a/lua/cosmic-ui/config.lua
+++ b/lua/cosmic-ui/config.lua
@@ -14,6 +14,7 @@ local defaults = {
   },
   codeactions = {
     min_width = nil,
+    auto_apply_preferred_if_single = false,
     border = {
       bottom_hl = 'FloatBorder',
       highlight = 'FloatBorder',

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@ Cosmic-UI is a simple wrapper around specific vim functionality. Built in order 
 
 - Rename floating popup & file change notification
 - Code Actions
+- Preferred code action quick-apply
 - Formatter toggles (LSP + Conform.nvim)
 
 ## 📷 Screenshots
@@ -71,6 +72,7 @@ You may override any of the settings below by passing a config object to `.setup
   codeactions = {
     enabled = true, -- optional (defaults to true when table exists)
     min_width = nil,
+    auto_apply_preferred_if_single = false,
     border = {
       bottom_hl = 'FloatBorder',
       highlight = 'FloatBorder',
@@ -142,6 +144,10 @@ end, { silent = true, desc = "Code actions" })
 vim.keymap.set("v", "<leader>ga", function()
   require("cosmic-ui").codeactions.range()
 end, { silent = true, desc = "Range code actions" })
+
+vim.keymap.set("n", "<leader>gA", function()
+  require("cosmic-ui").codeactions.preferred()
+end, { silent = true, desc = "Preferred code action" })
 ```
 
 ### Formatters


### PR DESCRIPTION
## Summary
- add `codeactions.preferred(opts?)` to request code actions and execute a unique preferred action directly
- add `codeactions.auto_apply_preferred_if_single` config so regular `open/range` flows can skip the menu when a single preferred action exists
- extract code action execution/resolve logic into `lua/cosmic-ui/codeactions/execute.lua` and reuse it in the picker path
- update README and module docs for the new API and config

## Validation
- `nvim --headless -u NONE "+set rtp+=." +"lua local c=require('cosmic-ui'); c.setup({codeactions={}}); c.codeactions.open(); c.codeactions.preferred({fallback_to_menu=false}); c.codeactions.range({range={start={1,0},['end']={1,0}}})" +qa`
  - expected warnings in sandbox: no attached LSP clients
  - sandbox-specific ShaDa temp-file permission warning observed
