### PR TITLE
Polish Cosmic UI panels and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .nvimlog
+.worktrees/

--- a/doc/cosmic-ui.txt
+++ b/doc/cosmic-ui.txt
@@ -1,4 +1,4 @@
-*cosmic-ui.txt*    cosmic-ui for Neovim 0.11+    Last change: 2026 Mar 16
+*cosmic-ui.txt*    cosmic-ui for Neovim 0.11+    Last change: 2026 Mar 20
 
 ==============================================================================
 CONTENTS                                                     *cosmic-ui-contents*
@@ -10,14 +10,16 @@ CONTENTS                                                     *cosmic-ui-contents
 5. Rename .................................................. |cosmic-ui.rename|
 6. Code Actions ...................................... |cosmic-ui.codeactions|
 7. Formatters ........................................ |cosmic-ui.formatters|
-8. Troubleshooting ............................. |cosmic-ui-troubleshooting|
-9. Keymap Examples ..................................... |cosmic-ui-examples|
+8. Commands ......................................... |cosmic-ui-commands|
+9. Troubleshooting ............................. |cosmic-ui-troubleshooting|
+10. Keymap Examples .................................... |cosmic-ui-examples|
 
 ==============================================================================
 1. Overview                                                   *cosmic-ui-overview*
 
 cosmic-ui provides floating UI wrappers around built-in Neovim LSP workflows.
-Its public surface is Lua-only; the plugin does not define Ex commands.
+Its primary public surface is Lua APIs, with optional Ex commands for
+discoverability.
 
 Current modules:
 
@@ -25,6 +27,13 @@ Current modules:
 - codeactions: floating picker for cursor and visual-range code actions
 - formatters: UI and API for toggling LSP/Conform formatters per buffer or
   globally
+
+Optional commands:
+
+- :CosmicRename
+- :CosmicCodeActions
+- :CosmicFormatters
+- :CosmicFormat
 
 Open this help any time with: >
   :help cosmic-ui
@@ -204,6 +213,10 @@ Example: >
   })
 <
 
+Optional Ex command:
+
+- :CosmicRename        Open the Cosmic rename prompt
+
 See also: |vim.lsp.buf.rename()| |lsp-core|
 
 ==============================================================================
@@ -253,6 +266,10 @@ Examples: >
 
   require("cosmic-ui").codeactions.range()
 <
+
+Optional Ex command:
+
+- :CosmicCodeActions   Open the Cosmic code action panel
 
 See also: |vim.lsp.buf.code_action()| |lsp-core|
 
@@ -371,8 +388,25 @@ Examples: >
   fmt.format_async({ backend = { "conform", "lsp" } })
 <
 
+Optional Ex commands:
+
+- :CosmicFormatters   Open the Cosmic formatter panel
+- :CosmicFormat       Format the current buffer
+
 ==============================================================================
-8. Troubleshooting                                   *cosmic-ui-troubleshooting*
+8. Commands                                                 *cosmic-ui-commands*
+
+cosmic-ui keeps Lua APIs first-class and also exposes optional commands:
+
+- :CosmicRename        Open the Cosmic rename prompt
+- :CosmicCodeActions   Open the Cosmic code action panel
+- :CosmicFormatters    Open the Cosmic formatter panel
+- :CosmicFormat        Format the current buffer
+
+These commands call the same module APIs documented above.
+
+==============================================================================
+9. Troubleshooting                                   *cosmic-ui-troubleshooting*
 
 setup() warnings:
 
@@ -407,7 +441,7 @@ General LSP debugging:
 - Run `:checkhealth vim.lsp` and review |lsp-core|.
 
 ==============================================================================
-9. Keymap Examples                                           *cosmic-ui-examples*
+10. Keymap Examples                                          *cosmic-ui-examples*
 
 Example keymaps: >
   vim.keymap.set("n", "gn", function()

--- a/docs/codeactions.md
+++ b/docs/codeactions.md
@@ -2,6 +2,7 @@
 
 Code actions module for `cosmic-ui`.
 This module validates setup/module enable state and runs code action requests directly.
+Lua API is primary; `:CosmicCodeActions` is an optional wrapper.
 
 ## Setup
 
@@ -91,3 +92,7 @@ require("cosmic-ui").codeactions.range({
   range = { start = { 10, 0 }, ["end"] = { 12, 0 } },
 })
 ```
+
+Optional command:
+
+- `:CosmicCodeActions` opens the Cosmic code action panel.

--- a/docs/codeactions.md
+++ b/docs/codeactions.md
@@ -57,7 +57,7 @@ Behavior:
 - opens a native floating menu (no NUI dependency)
 - menu groups are ordered deterministically by client name (tie-break: client id)
 - actions within each client group keep server response order
-- group headers are centered and rendered as bordered divider lines
+- group headers are rendered as plain section rows
 - selection index/count is shown in the float border footer (right-aligned)
 - keymaps: `j`/`k`, `<Down>`/`<Up>`, `<Tab>`/`<S-Tab>`, `<CR>`/`<Space>`, `<Esc>`/`<C-c>`
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,6 +16,14 @@ require("cosmic-ui").setup({
 
 If setup is not called, or a module is disabled, calls will warn and no-op.
 
+Lua APIs are the primary interface. Optional Ex commands are also available for
+discoverability:
+
+- `:CosmicRename`
+- `:CosmicCodeActions`
+- `:CosmicFormatters`
+- `:CosmicFormat`
+
 ## Rename
 
 Use when you want to rename the symbol under cursor.
@@ -43,6 +51,8 @@ vim.keymap.set("n", "gn", function()
   require("cosmic-ui").rename.open()
 end, { silent = true, desc = "Rename symbol" })
 ```
+
+Optional command: `:CosmicRename`
 
 ```lua
 require("cosmic-ui").rename.open({
@@ -105,6 +115,8 @@ vim.keymap.set("v", "<leader>ga", function()
   require("cosmic-ui").codeactions.range()
 end, { silent = true, desc = "Range code actions" })
 ```
+
+Optional command: `:CosmicCodeActions`
 
 ### Optional advanced opts
 
@@ -279,6 +291,11 @@ vim.keymap.set("n", "<leader>fm", function()
   require("cosmic-ui").formatters.format()
 end, { silent = true, desc = "Format" })
 ```
+
+Optional commands:
+
+- `:CosmicFormatters` opens the Cosmic formatter panel.
+- `:CosmicFormat` formats the current buffer.
 
 ```lua
 require("cosmic-ui").formatters.disable({

--- a/docs/formatters.md
+++ b/docs/formatters.md
@@ -2,6 +2,7 @@
 
 Formatter controls module for `cosmic-ui`.
 This module validates setup and module enable state, then executes formatter operations.
+Lua APIs are primary; `:CosmicFormatters` and `:CosmicFormat` are optional wrappers.
 
 ## Setup
 
@@ -187,6 +188,11 @@ fmt.open()
 fmt.toggle({ backend = "lsp" })
 fmt.format_async({ backend = { "conform", "lsp" } })
 ```
+
+Optional commands:
+
+- `:CosmicFormatters` opens the Cosmic formatter panel.
+- `:CosmicFormat` formats the current buffer.
 
 ### Conform `format_on_save` example
 

--- a/docs/rename.md
+++ b/docs/rename.md
@@ -47,7 +47,7 @@ Rename input options.
 | `window.row` | `integer\|nil` | No | `1` | Float row offset. |
 | `window.col` | `integer\|nil` | No | `0` | Float column offset. |
 | `window.width` | `integer\|nil` | No | auto-fit prompt + symbol | Float width. |
-| `window.height` | `integer\|nil` | No | `1` | Float height. |
+| `window.height` | `integer\|nil` | No | `5` | Float height. |
 | `window.zindex` | `integer\|nil` | No | `50` | Float z-index. |
 | `window.border` | `table\|nil` | No | from rename border config | Border/title overrides. |
 | `window.border.style` | `string\|table\|nil` | No | `vim.o.winborder` | Native border style. |

--- a/docs/rename.md
+++ b/docs/rename.md
@@ -2,6 +2,7 @@
 
 Rename UI module for `cosmic-ui`.
 This module validates setup and module enable state, then runs rename UI logic directly.
+Lua API is primary; `:CosmicRename` is an optional wrapper.
 
 ## Setup
 
@@ -81,3 +82,7 @@ require("cosmic-ui").rename.open({
   },
 })
 ```
+
+Optional command:
+
+- `:CosmicRename` opens the Cosmic rename prompt.

--- a/docs/superpowers/plans/2026-03-20-feature-polish.md
+++ b/docs/superpowers/plans/2026-03-20-feature-polish.md
@@ -1,0 +1,538 @@
+# Cosmic UI Feature Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved cross-feature polish pass so `rename`, `codeactions`, and `formatters` share a stronger Cosmic UI language, clearer state handling, and optional discoverability commands.
+
+**Architecture:** Add a small shared internal panel layer under `lua/cosmic-ui/ui/` for common float rendering, highlight setup, key-hint composition, and state rows. Migrate `codeactions` first as the reference implementation, then move `rename` onto the same prompt-panel model, and finally align `formatters` to the shared presentation and interaction rules without changing its core status logic.
+
+**Tech Stack:** Lua, Neovim 0.11 APIs, plenary.nvim (test harness), native Neovim floating windows, existing `cosmic-ui` modules and docs.
+
+---
+
+## File Structure
+
+### New files
+
+- `lua/cosmic-ui/ui/constants.lua`
+  Shared icons, spacing defaults, panel titles, and highlight link names used by all three UIs.
+- `lua/cosmic-ui/ui/highlights.lua`
+  Shared highlight creation and panel-level highlight application.
+- `lua/cosmic-ui/ui/panel.lua`
+  Shared float lifecycle helpers for titled panels, footer hints, cursorline behavior, and common state rendering.
+- `lua/cosmic-ui/ui/states.lua`
+  Helpers that build standard `loading`, `empty`, `unavailable`, and `error` row payloads.
+- `tests/minimal_init.lua`
+  Headless test bootstrap for runtimepath setup and Plenary test execution.
+- `tests/ui/panel_spec.lua`
+  Regression coverage for shared panel/state rendering.
+- `tests/codeactions/model_spec.lua`
+  Coverage for grouped rows, counts, and partial-error metadata.
+- `tests/codeactions/ui_spec.lua`
+  Coverage for code action state rendering and keymap behavior.
+- `tests/rename/ui_spec.lua`
+  Coverage for prompt validation and submit/cancel behavior.
+- `lua/cosmic-ui/rename/model.lua`
+  Isolated rename prompt normalization and validation helpers so prompt rules can be tested without opening a float.
+- `tests/formatters/rows_spec.lua`
+  Coverage for formatter row shaping and richer unavailable/empty rows.
+- `tests/commands_spec.lua`
+  Coverage for optional `:Cosmic...` command registration.
+
+### Modified files
+
+- `lua/cosmic-ui/window.lua`
+  Reuse shared window defaults and any new focus/cursor restoration helpers needed by the panel layer.
+- `lua/cosmic-ui/codeactions/request.lua`
+  Preserve per-client success/error data so the UI can render partial failures and loading completion cleanly.
+- `lua/cosmic-ui/codeactions/ui/init.lua`
+  Switch to the shared panel layer and structured state handling.
+- `lua/cosmic-ui/codeactions/ui/model.lua`
+  Build section rows, action rows, count metadata, and partial-error status rows.
+- `lua/cosmic-ui/codeactions/ui/render.lua`
+  Apply shared panel rendering instead of bespoke list rendering.
+- `lua/cosmic-ui/codeactions/ui/input.lua`
+  Keep current navigation and add optional numeric picks for short lists.
+- `lua/cosmic-ui/codeactions/ui/lifecycle.lua`
+  Align panel lifecycle and focus restoration with the shared layer.
+- `lua/cosmic-ui/rename/ui.lua`
+  Refactor the current one-line prompt into a compact prompt panel with inline validation.
+- `lua/cosmic-ui/formatters/constants.lua`
+  Remove formatter-only UI constants that move into the shared UI layer; keep formatter-domain constants only.
+- `lua/cosmic-ui/formatters/ui/init.lua`
+  Open the formatter UI through the shared panel primitives.
+- `lua/cosmic-ui/formatters/ui/render.lua`
+  Adopt shared header/footer/state rendering.
+- `lua/cosmic-ui/formatters/ui/highlights.lua`
+  Keep formatter-specific row highlighting only where shared highlighting is insufficient.
+- `lua/cosmic-ui/formatters/ui/rows.lua`
+  Emit richer row metadata and clearer explanatory text.
+- `lua/cosmic-ui/formatters/ui/input.lua`
+  Preserve existing power-user mappings while aligning close/selection behavior.
+- `plugin/cosmic-ui.lua`
+  Register optional `:CosmicRename`, `:CosmicCodeActions`, `:CosmicFormatters`, and `:CosmicFormat` commands.
+- `doc/cosmic-ui.txt`
+  Document the polished behaviors and optional commands.
+- `readme.md`
+  Refresh feature descriptions and usage examples.
+- `docs/features.md`
+  Keep the repo-facing feature guide aligned with the new behavior.
+- `docs/rename.md`
+  Document the prompt panel behavior and validation states.
+- `docs/codeactions.md`
+  Document the action panel states and optional command.
+- `docs/formatters.md`
+  Document the aligned panel behavior and optional commands.
+
+## Task 1: Test Harness Bootstrap
+
+**Files:**
+- Create: `tests/minimal_init.lua`
+- Create: `tests/ui/panel_spec.lua`
+
+- [ ] **Step 1: Write the failing smoke test for the shared panel layer**
+
+```lua
+describe("cosmic-ui.ui.panel", function()
+  it("builds a standard empty state row", function()
+    local states = require("cosmic-ui.ui.states")
+    local row = states.empty("No code actions found")
+    assert.are.equal("empty", row.state)
+    assert.are.equal("No code actions found", row.text)
+  end)
+end)
+```
+
+- [ ] **Step 2: Add the headless Neovim test bootstrap**
+
+```lua
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+for _, path in ipairs(vim.fn.globpath(vim.fn.stdpath("data") .. "/site/pack/*/start", "plenary.nvim", false, true)) do
+  vim.opt.runtimepath:append(path)
+end
+vim.opt.swapfile = false
+vim.opt.shadafile = "NONE"
+```
+
+- [ ] **Step 3: Run the targeted test and confirm it fails because the shared UI modules do not exist yet**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/ui/panel_spec.lua" -c qa`
+
+Expected: FAIL with `module 'cosmic-ui.ui.states' not found` or equivalent missing-module error.
+
+- [ ] **Step 4: Add the minimal shared UI module skeletons needed by the smoke test**
+
+```lua
+-- lua/cosmic-ui/ui/states.lua
+local M = {}
+
+function M.empty(text)
+  return { kind = "state", state = "empty", text = text }
+end
+
+return M
+```
+
+- [ ] **Step 5: Re-run the targeted test and confirm it passes**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/ui/panel_spec.lua" -c qa`
+
+Expected: PASS for the smoke test.
+
+- [ ] **Step 6: Commit the harness bootstrap**
+
+```bash
+git add tests/minimal_init.lua tests/ui/panel_spec.lua lua/cosmic-ui/ui/states.lua
+git commit -m "test: bootstrap headless ui specs"
+```
+
+## Task 2: Shared Cosmic Panel Infrastructure
+
+**Files:**
+- Create: `lua/cosmic-ui/ui/constants.lua`
+- Create: `lua/cosmic-ui/ui/highlights.lua`
+- Create: `lua/cosmic-ui/ui/panel.lua`
+- Modify: `lua/cosmic-ui/window.lua`
+- Test: `tests/ui/panel_spec.lua`
+
+- [ ] **Step 1: Expand the shared panel spec with failing coverage for header/footer/state rendering**
+
+```lua
+it("normalizes panel metadata for title, subtitle, and footer hints", function()
+  local panel = require("cosmic-ui.ui.panel")
+  local model = panel.build({
+    title = "Code Actions",
+    subtitle = "lua • 3 actions",
+    footer = { "Enter:apply", "Esc:close" },
+    rows = { { kind = "state", state = "empty", text = "No code actions found" } },
+  })
+
+  assert.are.equal("Code Actions", model.title)
+  assert.are.equal("lua • 3 actions", model.subtitle)
+  assert.are.same({ "Enter:apply", "Esc:close" }, model.footer)
+end)
+```
+
+- [ ] **Step 2: Run the shared UI spec and confirm it fails on missing `panel` and highlight behavior**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/ui/panel_spec.lua" -c qa`
+
+Expected: FAIL with missing module or missing field assertions for panel metadata.
+
+- [ ] **Step 3: Implement the shared constants, highlight links, and panel builder**
+
+```lua
+-- lua/cosmic-ui/ui/constants.lua
+return {
+  padding = { x = 1, y = 0 },
+  hints = { submit = "Enter", close = "Esc" },
+  highlight_links = {
+    CosmicUiPanelTitle = "Title",
+    CosmicUiPanelSubtitle = "Comment",
+    CosmicUiPanelSection = "Type",
+    CosmicUiPanelHintKey = "Special",
+    CosmicUiPanelHintText = "Comment",
+    CosmicUiPanelStateInfo = "Comment",
+    CosmicUiPanelStateWarn = "WarningMsg",
+    CosmicUiPanelStateError = "ErrorMsg",
+  },
+}
+```
+
+```lua
+-- lua/cosmic-ui/ui/panel.lua
+local M = {}
+
+function M.build(opts)
+  return {
+    title = opts.title,
+    subtitle = opts.subtitle,
+    footer = opts.footer or {},
+    rows = opts.rows or {},
+    selected = opts.selected,
+  }
+end
+
+return M
+```
+
+- [ ] **Step 4: Add the window/focus helpers the shared layer needs and keep them generic**
+
+```lua
+function M.restore_focus(win)
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_set_current_win(win)
+  end
+end
+```
+
+- [ ] **Step 5: Re-run the shared panel spec and confirm it passes**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/ui/panel_spec.lua" -c qa`
+
+Expected: PASS for the shared panel/state tests.
+
+- [ ] **Step 6: Commit the shared infrastructure**
+
+```bash
+git add lua/cosmic-ui/ui/constants.lua lua/cosmic-ui/ui/highlights.lua lua/cosmic-ui/ui/panel.lua lua/cosmic-ui/ui/states.lua lua/cosmic-ui/window.lua tests/ui/panel_spec.lua
+git commit -m "feat: add shared cosmic panel primitives"
+```
+
+## Task 3: Codeactions Migration
+
+**Files:**
+- Modify: `lua/cosmic-ui/codeactions/request.lua`
+- Modify: `lua/cosmic-ui/codeactions/ui/init.lua`
+- Modify: `lua/cosmic-ui/codeactions/ui/model.lua`
+- Modify: `lua/cosmic-ui/codeactions/ui/render.lua`
+- Modify: `lua/cosmic-ui/codeactions/ui/input.lua`
+- Modify: `lua/cosmic-ui/codeactions/ui/lifecycle.lua`
+- Test: `tests/codeactions/model_spec.lua`
+- Test: `tests/codeactions/ui_spec.lua`
+
+- [ ] **Step 1: Write failing model specs for grouped rows, counts, and partial failures**
+
+```lua
+it("keeps successful actions visible when one client errors", function()
+  local model = require("cosmic-ui.codeactions.ui.model")
+  local built = model.build({
+    [1] = {
+      client = { id = 1, name = "lua_ls" },
+      result = { { title = "Organize Imports" } },
+    },
+    [2] = {
+      client = { id = 2, name = "eslint" },
+      error = { code = -1, message = "request failed" },
+      result = nil,
+    },
+  })
+
+  assert.are.equal(1, #built.actions)
+  assert.are.equal(true, built.has_partial_error)
+end)
+```
+
+- [ ] **Step 2: Run the codeactions specs and confirm they fail against the current model**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/codeactions/model_spec.lua" -c "PlenaryBustedFile tests/codeactions/ui_spec.lua" -c qa`
+
+Expected: FAIL because partial-error metadata, state rows, and shared panel rendering do not exist yet.
+
+- [ ] **Step 3: Update request/model/init code to keep enough metadata for `loading`, `empty`, and partial-failure states**
+
+```lua
+return {
+  rows = rows,
+  actions = actions,
+  min_width = min_width,
+  title = "Code Actions",
+  subtitle = ("%s actions"):format(#actions),
+  has_partial_error = has_partial_error,
+  error_count = error_count,
+}
+```
+
+- [ ] **Step 4: Replace bespoke render/input behavior with shared panel rendering plus optional numeric picks**
+
+```lua
+map("n", "1", function() submit_index(1) end)
+map("n", "2", function() submit_index(2) end)
+```
+
+- [ ] **Step 5: Re-run the codeactions specs and then the full suite**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/codeactions/model_spec.lua" -c "PlenaryBustedFile tests/codeactions/ui_spec.lua" -c qa`
+
+Expected: PASS for codeactions specs.
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS for the full suite so far.
+
+- [ ] **Step 6: Commit the codeactions migration**
+
+```bash
+git add lua/cosmic-ui/codeactions/request.lua lua/cosmic-ui/codeactions/ui/init.lua lua/cosmic-ui/codeactions/ui/model.lua lua/cosmic-ui/codeactions/ui/render.lua lua/cosmic-ui/codeactions/ui/input.lua lua/cosmic-ui/codeactions/ui/lifecycle.lua tests/codeactions/model_spec.lua tests/codeactions/ui_spec.lua
+git commit -m "feat: polish codeactions panel states"
+```
+
+## Task 4: Rename Prompt Panel Migration
+
+**Files:**
+- Create: `lua/cosmic-ui/rename/model.lua`
+- Modify: `lua/cosmic-ui/rename/ui.lua`
+- Test: `tests/rename/ui_spec.lua`
+
+- [ ] **Step 1: Write failing rename specs for unchanged names, empty names, and restored focus on submit/cancel**
+
+```lua
+it("rejects empty submissions without dispatching rename", function()
+  local model = require("cosmic-ui.rename.model")
+  local result = model.normalize_submission("> ", "> ")
+  assert.are.same({ ok = false, reason = "empty" }, result)
+end)
+```
+
+- [ ] **Step 2: Run the rename spec and confirm it fails on missing helpers and validation behavior**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/rename/ui_spec.lua" -c qa`
+
+Expected: FAIL because `cosmic-ui.rename.model` and the new validation behavior do not exist yet.
+
+- [ ] **Step 3: Add `rename/model.lua` and refactor `rename/ui.lua` so normalization, rendering, and submit logic are isolated**
+
+```lua
+local M = {}
+
+function M.normalize_submission(prompt, raw_line, current_name)
+  local submitted = vim.startswith(raw_line, prompt) and raw_line:sub(#prompt + 1) or raw_line
+  if submitted == "" then
+    return { ok = false, reason = "empty" }
+  end
+  if submitted == current_name then
+    return { ok = false, reason = "unchanged" }
+  end
+  return { ok = true, value = submitted }
+end
+
+return M
+```
+
+- [ ] **Step 4: Render the rename UI through the shared prompt-panel structure and show inline validation copy**
+
+```lua
+local rows = {
+  { kind = "context", text = ("Current: %s"):format(curr_name) },
+  validation_row,
+}
+```
+
+- [ ] **Step 5: Re-run the rename spec and the full suite**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/rename/ui_spec.lua" -c qa`
+
+Expected: PASS for rename validation and focus behavior.
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS for the full suite.
+
+- [ ] **Step 6: Commit the rename migration**
+
+```bash
+git add lua/cosmic-ui/rename/model.lua lua/cosmic-ui/rename/ui.lua tests/rename/ui_spec.lua
+git commit -m "feat: polish rename prompt panel"
+```
+
+## Task 5: Formatters Alignment
+
+**Files:**
+- Modify: `lua/cosmic-ui/formatters/constants.lua`
+- Modify: `lua/cosmic-ui/formatters/ui/init.lua`
+- Modify: `lua/cosmic-ui/formatters/ui/render.lua`
+- Modify: `lua/cosmic-ui/formatters/ui/highlights.lua`
+- Modify: `lua/cosmic-ui/formatters/ui/rows.lua`
+- Modify: `lua/cosmic-ui/formatters/ui/input.lua`
+- Test: `tests/formatters/rows_spec.lua`
+
+- [ ] **Step 1: Write failing formatter row specs for richer unavailable/empty text and shared section metadata**
+
+```lua
+it("renders conform-unavailable rows with explanatory text", function()
+  local rows = require("cosmic-ui.formatters.ui.rows")
+  local built = rows.build_rows({
+    conform = { available = false, reason = "conform unavailable", formatters = {}, fallback = {} },
+    lsp_clients = {},
+  }, { conform = "C", lsp = "L", file = "F", filetype = "lua" }, { unavailable = "!" })
+
+  assert.is_truthy(vim.tbl_contains(vim.tbl_map(function(row) return row.id end, built), "conform_unavailable"))
+end)
+```
+
+- [ ] **Step 2: Run the formatter spec and confirm it fails against the current row shape**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/formatters/rows_spec.lua" -c qa`
+
+Expected: FAIL because the current rows do not carry the richer shared-panel metadata yet.
+
+- [ ] **Step 3: Move only generic UI constants to the shared layer and update formatter rows/rendering to consume it**
+
+```lua
+table.insert(rows, {
+  id = "section_lsp",
+  kind = "section",
+  text = "LSP",
+  subtitle = lsp_header_mode,
+})
+```
+
+- [ ] **Step 4: Update formatter input/footer rendering so the panel still exposes scope/reset/toggle/format actions but with the shared footer style**
+
+```lua
+ui.footer = {
+  "Tab:toggle",
+  "s:scope",
+  "r:reset",
+  "a:toggle all",
+  "f:format",
+  "q:close",
+}
+```
+
+- [ ] **Step 5: Re-run the formatter spec and the full suite**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/formatters/rows_spec.lua" -c qa`
+
+Expected: PASS for formatter row/rendering coverage.
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS for the full suite.
+
+- [ ] **Step 6: Commit the formatter alignment**
+
+```bash
+git add lua/cosmic-ui/formatters/constants.lua lua/cosmic-ui/formatters/ui/init.lua lua/cosmic-ui/formatters/ui/render.lua lua/cosmic-ui/formatters/ui/highlights.lua lua/cosmic-ui/formatters/ui/rows.lua lua/cosmic-ui/formatters/ui/input.lua tests/formatters/rows_spec.lua
+git commit -m "feat: align formatter panel with cosmic ui"
+```
+
+## Task 6: Commands and Documentation
+
+**Files:**
+- Create: `tests/commands_spec.lua`
+- Modify: `plugin/cosmic-ui.lua`
+- Modify: `doc/cosmic-ui.txt`
+- Modify: `readme.md`
+- Modify: `docs/features.md`
+- Modify: `docs/rename.md`
+- Modify: `docs/codeactions.md`
+- Modify: `docs/formatters.md`
+
+- [ ] **Step 1: Write the failing command spec**
+
+```lua
+it("registers optional Cosmic commands", function()
+  vim.cmd("runtime plugin/cosmic-ui.lua")
+  local commands = vim.api.nvim_get_commands({})
+  assert.is_truthy(commands.CosmicRename)
+  assert.is_truthy(commands.CosmicCodeActions)
+  assert.is_truthy(commands.CosmicFormatters)
+  assert.is_truthy(commands.CosmicFormat)
+end)
+```
+
+- [ ] **Step 2: Run the command/doc spec and confirm the commands are not registered yet**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/commands_spec.lua" -c qa`
+
+Expected: FAIL because the commands do not exist yet.
+
+- [ ] **Step 3: Add the commands in `plugin/cosmic-ui.lua` and wire them to the existing Lua APIs**
+
+```lua
+vim.api.nvim_create_user_command("CosmicRename", function()
+  require("cosmic-ui").rename.open()
+end, {})
+```
+
+- [ ] **Step 4: Update help and Markdown docs to describe the polished panels and optional commands**
+
+```text
+:CosmicCodeActions   Open the Cosmic code action panel
+:CosmicRename        Open the Cosmic rename prompt
+```
+
+- [ ] **Step 5: Run command spec, then run formatting, then run the full suite**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile tests/commands_spec.lua" -c qa`
+
+Expected: PASS for command registration.
+
+Run: `stylua lua plugin tests`
+
+Expected: formatting succeeds with no parse errors.
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS for all tests.
+
+- [ ] **Step 6: Commit commands and docs**
+
+```bash
+git add plugin/cosmic-ui.lua doc/cosmic-ui.txt readme.md docs/features.md docs/rename.md docs/codeactions.md docs/formatters.md tests/commands_spec.lua
+git commit -m "docs: add cosmic ui command and polish docs"
+```
+
+## Final Verification
+
+- [ ] Run: `stylua lua plugin tests`
+  Expected: no formatting errors.
+- [ ] Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+  Expected: full suite passes.
+- [ ] Run a manual smoke pass in Neovim for:
+  - `require("cosmic-ui").codeactions.open()`
+  - `require("cosmic-ui").rename.open()`
+  - `require("cosmic-ui").formatters.open()`
+  - `:CosmicCodeActions`, `:CosmicRename`, `:CosmicFormatters`, `:CosmicFormat`
+- [ ] Confirm `readme.md` and `doc/cosmic-ui.txt` describe the same commands and polished behaviors.

--- a/docs/superpowers/plans/2026-03-20-shared-panel-layout-variants.md
+++ b/docs/superpowers/plans/2026-03-20-shared-panel-layout-variants.md
@@ -1,0 +1,286 @@
+# Shared Panel Layout Variants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add shared panel layout variants so `rename` defaults to a compact single-line prompt that behaves like `main` while `codeactions` and `formatters` stay on the richer shared panel layout.
+
+**Architecture:** Extend `lua/cosmic-ui/ui/panel.lua` to normalize a `layout = 'standard' | 'compact'` field and keep `standard` as the default. Then move `rename` onto `layout = 'compact'` using the existing shared panel metadata path, but render only the prompt line in the buffer and restore the old cursor/edit/submit semantics from `main` without forking back to a separate non-panel implementation.
+
+**Tech Stack:** Lua, Neovim 0.11 APIs, plenary.nvim test harness, native floating windows, existing `cosmic-ui` modules.
+
+---
+
+## File Structure
+
+### Modified files
+
+- `lua/cosmic-ui/ui/panel.lua`
+  Normalize and expose `layout = 'standard' | 'compact'` on shared panel models.
+- `tests/ui/panel_spec.lua`
+  Add regression coverage for layout normalization and defaulting.
+- `lua/cosmic-ui/rename/ui.lua`
+  Make `rename` build a shared panel with `layout = 'compact'` and render a single-line prompt buffer using shared metadata but old prompt behavior.
+- `tests/rename/ui_spec.lua`
+  Replace multi-line-panel expectations with compact rename behavior expectations and keep validation/submit coverage aligned with `main`-style interaction.
+
+### No new files expected
+
+- Keep this implementation narrow. Do not add a new public config surface or a rename-only UI module unless the shared panel layout boundary proves insufficient.
+
+## Task 1: Add Shared Panel Layout Normalization
+
+**Files:**
+- Modify: `lua/cosmic-ui/ui/panel.lua`
+- Modify: `tests/ui/panel_spec.lua`
+
+- [ ] **Step 1: Add the failing shared-panel layout spec**
+
+```lua
+it('defaults panel layout to standard and preserves compact when requested', function()
+  local panel = require('cosmic-ui.ui.panel')
+
+  assert.are.equal('standard', panel.build({}).layout)
+  assert.are.equal('compact', panel.build({ layout = 'compact' }).layout)
+end)
+```
+
+- [ ] **Step 2: Run the shared UI spec and confirm it fails on missing `layout` support**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ui { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: FAIL because `panel.build()` does not currently return a `layout` field.
+
+- [ ] **Step 3: Implement layout normalization in the shared panel model**
+
+```lua
+local function normalize_layout(layout)
+  if layout == 'compact' then
+    return 'compact'
+  end
+  return 'standard'
+end
+
+function M.build(opts)
+  opts = opts or {}
+  local rows = normalize_rows(opts.rows)
+
+  return {
+    layout = normalize_layout(opts.layout),
+    title = opts.title or '',
+    subtitle = opts.subtitle or '',
+    footer = normalize_footer(opts.footer),
+    rows = rows,
+    selected = normalize_selected(opts.selected, rows),
+  }
+end
+```
+
+- [ ] **Step 4: Re-run the shared UI spec and confirm it passes**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ui { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS for the shared panel spec, including the new layout assertions.
+
+- [ ] **Step 5: Commit the shared layout normalization**
+
+```bash
+git add lua/cosmic-ui/ui/panel.lua tests/ui/panel_spec.lua
+git commit -m "feat: add shared panel layout variants"
+```
+
+## Task 2: Move Rename to Compact Shared-Panel Behavior
+
+**Files:**
+- Modify: `lua/cosmic-ui/rename/ui.lua`
+- Modify: `tests/rename/ui_spec.lua`
+
+- [ ] **Step 1: Add failing rename specs for compact default behavior**
+
+```lua
+it('renders only the prompt line for the default compact layout', function()
+  stub_rename_context('current_name')
+  local ui = require('cosmic-ui.rename.ui')
+
+  ui.open({ default_value = 'next_name' })
+
+  assert.are.same({ '> next_name' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+end)
+
+it('does not render footer helper rows into the compact rename buffer', function()
+  stub_rename_context('current_name')
+  local ui = require('cosmic-ui.rename.ui')
+
+  ui.open({ default_value = 'next_name' })
+
+  assert.is_false(vim.tbl_contains(vim.api.nvim_buf_get_lines(0, 0, -1, false), ' Enter:rename  Esc:cancel '))
+end)
+```
+
+- [ ] **Step 2: Run the rename spec and confirm it fails against the current multi-line rename panel**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/rename { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: FAIL because `rename` currently renders context/footer rows and uses multi-line panel structure.
+
+- [ ] **Step 3: Make `rename` build a compact shared panel and render only the prompt line**
+
+```lua
+local function build_panel_model(curr_name, reason)
+  return panel.prepare({
+    layout = 'compact',
+    title = 'Rename',
+    rows = {},
+    footer = {
+      { key = 'Enter', text = 'rename' },
+      { key = 'Esc', text = 'cancel' },
+    },
+  })
+end
+
+local function render(ui, value)
+  ui.value = value
+  ui.panel = build_panel_model(ui.curr_name, ui.validation_reason)
+
+  local prompt_line = ui.prompt .. value
+  vim.bo[ui.buf].modifiable = true
+  vim.api.nvim_buf_set_lines(ui.buf, 0, -1, false, { prompt_line })
+  vim.bo[ui.buf].modifiable = true
+
+  ui.prompt_row = 1
+  ui.prompt_col = #ui.prompt
+end
+```
+
+Implementation notes:
+
+- Keep using `panel.prepare()` and shared title/footer metadata even though compact layout does not render footer/context rows into buffer lines.
+- Preserve border/title config through the current merged window options path.
+- Keep prompt extmark highlighting.
+- Restore the old single-line cursor math from `main` where compact layout is active.
+
+- [ ] **Step 4: Re-run the rename spec and confirm the compact buffer tests pass**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/rename { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS for the new single-line buffer expectations, with any still-failing old multi-line expectations identified for cleanup in the next task.
+
+- [ ] **Step 5: Commit the compact rename default**
+
+```bash
+git add lua/cosmic-ui/rename/ui.lua tests/rename/ui_spec.lua
+git commit -m "feat: default rename to compact panel layout"
+```
+
+## Task 3: Align Rename Interaction Semantics with Main
+
+**Files:**
+- Modify: `lua/cosmic-ui/rename/ui.lua`
+- Modify: `tests/rename/ui_spec.lua`
+
+- [ ] **Step 1: Replace now-invalid multi-line rename assertions with main-style behavior checks**
+
+```lua
+it('keeps the compact rename buffer modifiable for prompt editing', function()
+  stub_rename_context('current_name')
+  local ui = require('cosmic-ui.rename.ui')
+
+  ui.open({ default_value = 'draft' })
+
+  assert.is_true(vim.bo[vim.api.nvim_get_current_buf()].modifiable)
+  assert.are.equal(1, #vim.api.nvim_buf_get_lines(0, 0, -1, false))
+end)
+
+it('keeps the cursor constrained to the prompt line in compact layout', function()
+  stub_rename_context('current_name')
+  local ui = require('cosmic-ui.rename.ui')
+
+  ui.open({ default_value = 'draft' })
+  vim.api.nvim_win_set_cursor(0, { 1, 0 })
+  vim.wait(1000, function()
+    return vim.api.nvim_win_get_cursor(0)[2] == 2
+  end)
+
+  assert.are.same({ 1, 2 }, vim.api.nvim_win_get_cursor(0))
+end)
+```
+
+- [ ] **Step 2: Run the rename spec and confirm it fails on any remaining behavior drift**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/rename { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: FAIL on any remaining differences in prompt mutability, cursor rules, submit handling, or compact rendering assumptions.
+
+- [ ] **Step 3: Restore old rename prompt semantics while staying on shared metadata**
+
+```lua
+local buf = window.create_scratch_buf({
+  filetype = 'cosmicui-rename',
+  modifiable = true,
+  bufhidden = 'wipe',
+})
+
+local function ensure_cursor_after_prompt(ui)
+  local cursor = vim.api.nvim_win_get_cursor(ui.win)
+  local current_line = vim.api.nvim_buf_get_lines(ui.buf, 0, 1, true)[1] or ''
+  local min_col = #ui.prompt
+  local max_col = #current_line
+
+  if cursor[2] < min_col then
+    set_cursor_col(ui, min_col)
+  elseif cursor[2] > max_col then
+    set_cursor_col(ui, max_col)
+  end
+end
+```
+
+Implementation notes:
+
+- Remove compact-layout footer highlight assertions and multi-line edit-lock behavior from the rename tests. Those belong to `standard`, not compact.
+- Keep `model.normalize_submission()` and validation correctness.
+- Do not reintroduce context/footer rows as hidden state inside the buffer.
+- If current focus restoration differs from `main`, prefer the old rename close behavior unless a specific regression test proves otherwise.
+
+- [ ] **Step 4: Re-run the rename spec and confirm it passes**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/rename { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS for compact single-line rename behavior, prompt editing, submit/cancel, and validation tests.
+
+- [ ] **Step 5: Commit the behavior-alignment cleanup**
+
+```bash
+git add lua/cosmic-ui/rename/ui.lua tests/rename/ui_spec.lua
+git commit -m "fix: align compact rename behavior with main"
+```
+
+## Task 4: Full Verification
+
+**Files:**
+- Modify: none expected
+
+- [ ] **Step 1: Run formatting**
+
+Run: `stylua lua plugin tests`
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c qa`
+
+Expected: PASS with 0 failures and 0 errors.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run: `git diff --stat HEAD~3..HEAD`
+
+Expected: only shared panel layout normalization and compact rename behavior changes.
+
+- [ ] **Step 4: Commit any final formatting-only fallout if needed**
+
+```bash
+git add lua/cosmic-ui/ui/panel.lua lua/cosmic-ui/rename/ui.lua tests/ui/panel_spec.lua tests/rename/ui_spec.lua
+git commit -m "style: format shared panel layout changes"
+```
+
+Only do this if `stylua` changes files after the feature commits.

--- a/docs/superpowers/specs/2026-03-20-feature-polish-design.md
+++ b/docs/superpowers/specs/2026-03-20-feature-polish-design.md
@@ -1,0 +1,239 @@
+# Cosmic UI Feature Polish Design
+
+Date: 2026-03-20
+Status: Approved for planning
+
+## Summary
+
+This design defines a cross-feature polish pass for `cosmic-ui` focused on visual quality, clearer interaction design, and stronger handling of imperfect states. The work covers `rename`, `codeactions`, and `formatters`, with `codeactions` serving as the reference surface for the shared UI language.
+
+The goal is not to expand the plugin into a different product. The goal is to make the existing features feel intentionally designed, resilient, and recognizably "Cosmic" while preserving the current Lua API surface and keeping any new affordances optional.
+
+## Goals
+
+- Give all three features a coherent visual identity and interaction model.
+- Improve readability with stronger hierarchy, clearer labels, and more expressive state rendering.
+- Make loading, empty, unavailable, and error states explicit inside the UI where possible.
+- Improve keyboard flow and focus restoration so interactions feel deliberate instead of fragile.
+- Allow optional discoverability affordances, including Ex commands, without replacing the Lua API-first model.
+
+## Non-Goals
+
+- Replacing the existing Lua APIs with command-only workflows.
+- Rewriting feature semantics such as how code actions are requested or how formatter state is computed.
+- Adding major new product areas unrelated to the current three feature modules.
+- Turning this pass into a broad architecture rewrite beyond UI and interaction infrastructure needed for the polish work.
+
+## Product Direction
+
+The post-polish plugin should feel more opinionated and more visually distinctive than it does today. The desired personality is "Cosmic": stronger than stock Neovim, but still compatible with native workflows and current plugin usage.
+
+Three principles define the pass:
+
+1. Shared identity
+   Every float should feel like part of the same product, with consistent titles, spacing, section treatment, status language, and key-hint patterns.
+
+2. Explicit states
+   When nothing useful can happen, the UI should say exactly why. Silent closes, vague warnings, and visually ambiguous empty states should be reduced.
+
+3. Predictable interaction
+   Selection, submit, cancel, navigation, and focus restoration should behave consistently across all feature surfaces.
+
+## Shared UI Model
+
+Introduce a shared internal panel layer used by list-style and prompt-style floats. This is internal infrastructure, not a new public API commitment.
+
+The shared panel model should support:
+
+- Header area
+  - Primary title
+  - Optional subtitle or context line
+  - Optional status badge or count
+- Body area
+  - Rows for list-based UIs
+  - Prompt layout for input-based UIs
+  - Consistent padding and highlight treatment
+- Footer area
+  - Compact key hints
+  - Brief state text when needed
+- Shared states
+  - `loading`
+  - `ready`
+  - `empty`
+  - `unavailable`
+  - `error`
+- Shared interaction behavior
+  - next/previous movement
+  - wrap behavior
+  - submit and cancel
+  - focus restoration to the originating window
+
+The shared layer is responsible for presentation and interaction behavior, not feature-specific meaning. Feature modules keep ownership of request building, response transformation, formatter status computation, and rename submission logic.
+
+## Feature Design
+
+## Codeactions
+
+`codeactions` becomes the reference implementation for the new panel model.
+
+Desired behavior:
+
+- Render as a real action panel rather than a minimally formatted list.
+- Keep deterministic grouping by client, but present each client as a proper section header instead of divider text.
+- Show more context up front, such as action count and a lightweight subtitle for the current request context.
+- Make the current selection visually obvious.
+
+State handling:
+
+- `loading`: visible while client requests are in flight.
+- `empty`: explicit "no actions found" state instead of an abrupt no-result outcome.
+- `error`: explicit failure message when request execution fails.
+- partial failure: when some clients fail and others succeed, keep usable results visible and surface that the response is incomplete.
+
+Interaction:
+
+- Keep `j/k`, arrow keys, `Tab`, `Enter`, `Esc`, and `Ctrl-c`.
+- Preserve quick confirm on `Enter`.
+- If the action list is short, allow optional direct numeric activation for the first visible actions.
+- Closing the panel must restore focus cleanly.
+
+Optional discoverability:
+
+- `:CosmicCodeActions`
+
+Not required in the initial implementation:
+
+- Auto-apply single action behavior. This may be considered later, but it is not part of this design by default.
+
+## Rename
+
+`rename` should become a compact prompt panel instead of a bare one-line input float.
+
+Desired behavior:
+
+- Show a title and brief context around the current symbol.
+- Present the prompt with clearer structure and spacing.
+- Preserve the current simple rename flow while making the interaction feel intentional.
+
+State handling:
+
+- `unavailable`: clear in-UI explanation when no rename-capable LSP clients are attached.
+- validation feedback for:
+  - unchanged name
+  - empty input
+- avoid fragile-feeling cursor behavior around the prompt prefix.
+
+Interaction:
+
+- Submit and cancel should match the other panels.
+- Cursor placement and editing should feel like a dedicated prompt, not a raw buffer trick.
+- Closing should restore the originating context reliably before dispatching the rename.
+
+Optional discoverability:
+
+- `:CosmicRename`
+
+## Formatters
+
+`formatters` already has the richest UI structure and should be visually aligned with the new panel model instead of replaced.
+
+Desired behavior:
+
+- Keep the current capability set: scope switching, item toggling, reset, and format actions.
+- Improve scanability of section headers, backend state, scope state, and row meaning.
+- Surface more meaning in the rows themselves so the footer does less explanatory work.
+
+State handling:
+
+- Improve readability of unavailable and empty rows.
+- Keep detailed formatter and fallback status available, but render it in a more legible hierarchy.
+- Preserve informative backend state without making the panel feel dense or cryptic.
+
+Interaction:
+
+- Retain current power-user flows while making navigation and row intent clearer.
+- Keep scope switching, reset, toggle-all, and format actions available.
+- Align selection and close behavior with the shared panel model.
+
+Optional discoverability:
+
+- `:CosmicFormatters`
+- `:CosmicFormat`
+
+## Discoverability
+
+The plugin remains Lua API-first. Optional Ex commands are allowed where they materially improve discoverability or provide a more obvious entry point.
+
+Command additions in scope:
+
+- `:CosmicRename`
+- `:CosmicCodeActions`
+- `:CosmicFormatters`
+- `:CosmicFormat`
+
+These commands should be documented as convenience entry points, not replacements for the existing Lua API.
+
+## Architecture
+
+Implementation should favor small, well-bounded units:
+
+- shared panel/presentation modules for common float behavior
+- feature-specific adapters for row construction, state mapping, and submit actions
+- isolated highlight/state helpers where visual semantics are reused
+
+Expected architectural rules:
+
+- Keep public feature modules (`rename`, `codeactions`, `formatters`) as the user-facing boundary.
+- Do not push feature-specific business logic into shared UI infrastructure.
+- Prefer composable rendering/state helpers over large monolithic UI files.
+- Where existing files have become too presentation-heavy, split them along stable responsibilities rather than adding more branching in place.
+
+## Error Handling
+
+State handling should follow these rules:
+
+- If no float is opened, warnings/notifications may still be used.
+- Once a float is open, user feedback should be rendered inside the float first when practical.
+- Partial failures should not discard successful data if the feature can still proceed meaningfully.
+- Empty and unavailable states should be descriptive enough that a planner or implementer does not need to infer intent.
+
+## Testing
+
+Planning and implementation should include targeted coverage for:
+
+- shared row/state builders
+- selection behavior and wrap behavior
+- state rendering for `loading`, `empty`, `unavailable`, and `error`
+- code action grouping and partial failure handling
+- rename validation for unchanged and empty submissions
+- formatter row/status rendering when backends or items are unavailable
+- focus restoration and invalid buffer/window edge cases where applicable
+
+Documentation verification should include:
+
+- README updates
+- `:help cosmic-ui` updates
+- any new command documentation
+- examples that stay aligned with the final public behavior
+
+## Planning Constraints
+
+The implementation plan should stay focused on a single polish initiative, not multiple unrelated projects. It should treat shared panel infrastructure as support work for the three existing features, not as a new standalone framework.
+
+The plan should prioritize:
+
+1. shared UI primitives and state rendering
+2. `codeactions` migration to the new model
+3. `rename` migration to the new model
+4. `formatters` alignment with the new model
+5. optional command and documentation updates
+
+## Acceptance Criteria
+
+This design is successful when:
+
+- `rename`, `codeactions`, and `formatters` visibly share the same design language
+- empty, unavailable, and error situations are explicit and understandable
+- interaction flow feels consistent across all three features
+- optional commands improve discoverability without displacing Lua APIs
+- the resulting implementation plan can be written without inventing missing requirements

--- a/docs/superpowers/specs/2026-03-20-shared-panel-layout-variants-design.md
+++ b/docs/superpowers/specs/2026-03-20-shared-panel-layout-variants-design.md
@@ -1,0 +1,144 @@
+# Shared Panel Layout Variants Design
+
+Date: 2026-03-20
+Status: Approved for planning
+
+## Summary
+
+This design adds layout variants to the shared panel system so prompt-style flows can preserve old interaction behavior without abandoning shared panel infrastructure.
+
+The first concrete use is `rename`. It should keep using shared panel code, but its default behavior should match the old `main`-branch rename experience: a compact single-line prompt, old cursor/edit semantics, and no extra buffer rows for context or helper text.
+
+## Goals
+
+- Keep `rename` on shared panel infrastructure instead of restoring a fully separate float implementation.
+- Make `rename` default to the old interaction model from `main`.
+- Keep the current shared multi-line panel behavior available for list-style features.
+- Introduce the smallest shared API necessary to support both styles cleanly.
+
+## Non-Goals
+
+- Changing `codeactions` or `formatters` to compact prompt behavior.
+- Adding a user-facing layout toggle in setup config at this stage.
+- Reverting the shared panel work or restoring feature-specific UI code paths wholesale.
+- Treating visual differences in border/title chrome as regressions when behavior is intentionally preserved.
+
+## Product Direction
+
+Shared panel code should support multiple interaction shapes, not force every feature into the same in-buffer structure.
+
+The desired outcome is:
+
+- `codeactions` and `formatters` continue to use the richer shared panel presentation.
+- `rename` uses the same shared panel infrastructure, but renders as a compact prompt panel.
+- Shared visuals can evolve, but prompt behavior must remain appropriate for a rename flow.
+
+This keeps the codebase unified without flattening feature-specific interaction needs.
+
+## Shared Panel Model
+
+The shared panel model should add a `layout` field with two variants:
+
+- `standard`
+  The current shared multi-line panel layout. Suitable for action lists, formatter lists, and state-heavy panels.
+- `compact`
+  A minimal shared prompt layout. Suitable for prompt-driven flows where the buffer should primarily behave like an editable input line.
+
+Default behavior:
+
+- `layout = 'standard'` unless a feature selects otherwise.
+
+Responsibilities that remain shared across both layouts:
+
+- border and title metadata
+- window sizing hooks
+- highlight registration
+- panel lifecycle helpers
+- normalized panel/footer/title metadata
+
+Responsibilities that vary by layout:
+
+- which metadata is rendered into buffer lines
+- how many lines are rendered
+- whether helper/footer text is shown inside the buffer
+- how prompt-style cursor/edit rules are applied
+
+## Rename Default Behavior
+
+`rename` should default to `layout = 'compact'`.
+
+In compact layout, `rename` should behave like the old implementation:
+
+- render only the editable prompt line in the buffer
+- keep prompt editing semantics aligned with `main`
+- start in insert mode
+- constrain cursor movement within the prompt line
+- keep submission and cancel flow aligned with the old rename interaction
+
+Behavior explicitly not rendered into the buffer by default:
+
+- context rows such as `Current: <symbol>`
+- footer helper rows such as `Enter:rename`
+- validation/status rows
+
+Shared panel infrastructure may still receive this metadata, but compact layout should choose not to render it into buffer lines.
+
+Window-level chrome is still allowed:
+
+- border
+- title
+- border/title highlights
+
+Those do not conflict with the old rename behavior because they do not alter the editable buffer shape.
+
+## Architecture
+
+Implementation should preserve a single shared panel path while adding a layout boundary inside it.
+
+Expected structure:
+
+- shared panel normalization accepts `layout = 'standard' | 'compact'`
+- shared panel rendering helpers branch on layout only where buffer structure differs
+- `rename` builds a shared panel model with `layout = 'compact'`
+- `codeactions` and `formatters` continue to use `layout = 'standard'`
+
+Architectural rules:
+
+- Do not reintroduce a fully separate rename UI implementation.
+- Keep layout branching localized to shared panel rendering behavior.
+- Do not push rename-specific business logic into generic panel normalization.
+- If compact prompt behavior needs dedicated helpers, keep them shared and layout-oriented rather than feature-oriented.
+
+## Error Handling
+
+Compact layout should preserve old rename interaction behavior without losing current validation correctness.
+
+Rules:
+
+- no-client rename should still fail clearly before opening the prompt
+- empty and unchanged submissions should still be handled correctly
+- validation should not depend on rendering extra buffer rows
+- compact layout should avoid mutating the buffer in ways that make prompt editing feel unlike the old rename flow
+
+If feedback is needed for invalid submission, it should not force the compact buffer to become a multi-line panel by default.
+
+## Testing
+
+Planning and implementation should include:
+
+- shared panel unit coverage for layout normalization and defaulting
+- `rename` regression coverage proving compact layout renders a single-line prompt buffer
+- `rename` coverage proving helper/footer rows are not rendered into the buffer
+- `rename` coverage proving prompt editing remains possible
+- `rename` coverage proving submit/cancel/cursor behavior stays aligned with the old flow
+- confirmation that existing `codeactions` and `formatters` coverage stays green under `standard`
+
+## Acceptance Criteria
+
+This design is successful when:
+
+- shared panel supports `layout = 'standard' | 'compact'`
+- `rename` defaults to `compact`
+- `rename` behaves like the old single-line prompt flow while still using shared panel code
+- `codeactions` and `formatters` remain on the richer shared layout unchanged
+- implementation can proceed without reopening the question of whether rename should fork away from shared panel infrastructure

--- a/lua/cosmic-ui/codeactions/request.lua
+++ b/lua/cosmic-ui/codeactions/request.lua
@@ -46,12 +46,23 @@ M.collect = function(opts)
   local lnum = vim.api.nvim_win_get_cursor(0)[1] - 1
   local pending = #clients
   local results_lsp = {}
+  local request_state = {
+    status = 'loading',
+    responses = results_lsp,
+    total_clients = pending,
+    completed_clients = 0,
+  }
 
   if pending == 0 then
     if on_complete then
-      on_complete(results_lsp, user_opts)
+      request_state.status = 'ready'
+      on_complete(request_state, user_opts)
     end
     return
+  end
+
+  if on_complete then
+    on_complete(request_state, user_opts)
   end
 
   local function on_result(client)
@@ -62,13 +73,15 @@ M.collect = function(opts)
         client = client,
       }
 
+      request_state.completed_clients = request_state.completed_clients + 1
       pending = pending - 1
       if pending > 0 then
         return
       end
 
       if on_complete then
-        on_complete(results_lsp, user_opts)
+        request_state.status = 'ready'
+        on_complete(request_state, user_opts)
       end
     end
   end

--- a/lua/cosmic-ui/codeactions/request.lua
+++ b/lua/cosmic-ui/codeactions/request.lua
@@ -39,13 +39,17 @@ local function make_client_params(client, bufnr, opts, lnum)
 end
 
 M.collect = function(opts)
-  local bufnr = opts.bufnr or 0
+  local bufnr = opts.bufnr
+  if bufnr == nil or bufnr == 0 then
+    bufnr = vim.api.nvim_get_current_buf()
+  end
   local clients = opts.clients or {}
   local user_opts = opts.user_opts or {}
   local on_complete = opts.on_complete
   local lnum = vim.api.nvim_win_get_cursor(0)[1] - 1
   local pending = #clients
   local results_lsp = {}
+  local prepared_requests = {}
   local request_state = {
     status = 'loading',
     responses = results_lsp,
@@ -59,6 +63,13 @@ M.collect = function(opts)
       on_complete(request_state, user_opts)
     end
     return
+  end
+
+  for _, client in ipairs(clients) do
+    table.insert(prepared_requests, {
+      client = client,
+      params = make_client_params(client, bufnr, user_opts, lnum),
+    })
   end
 
   if on_complete then
@@ -86,9 +97,8 @@ M.collect = function(opts)
     end
   end
 
-  for _, client in ipairs(clients) do
-    local params = make_client_params(client, bufnr, user_opts, lnum)
-    client:request('textDocument/codeAction', params, on_result(client), bufnr)
+  for _, prepared in ipairs(prepared_requests) do
+    prepared.client:request('textDocument/codeAction', prepared.params, on_result(prepared.client), bufnr)
   end
 end
 

--- a/lua/cosmic-ui/codeactions/transform.lua
+++ b/lua/cosmic-ui/codeactions/transform.lua
@@ -48,7 +48,7 @@ M.supports_code_action_resolve = function(client)
   local code_action_provider = server_capabilities.codeActionProvider or server_capabilities.codeAction
 
   return type(code_action_provider) == 'table'
-      and (code_action_provider.resolveProvider or code_action_provider.resolve_provider)
+    and (code_action_provider.resolveProvider or code_action_provider.resolve_provider)
 end
 
 return M

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -10,6 +10,10 @@ local logger = utils.Logger
 
 local M = {}
 
+local function close_current()
+  lifecycle.close_current({ dismissed = false })
+end
+
 local function dismiss_current()
   lifecycle.close_current({ dismissed = true })
 end
@@ -85,12 +89,17 @@ M.open = function(results_lsp, user_opts)
 
   user_opts = user_opts or {}
   local built = model.build(results_lsp)
+  local origin_win = vim.api.nvim_get_current_win()
   local existing = lifecycle.get_state().ui
 
   if existing and vim.api.nvim_buf_is_valid(existing.buf) and vim.api.nvim_win_is_valid(existing.win) then
     existing.model = built
     existing.panel = build_panel_model(built)
-    existing.min_width = math.max(existing.min_width or 30, built.min_width or 30)
+    existing.min_width = math.max(existing.min_width or 30, user_opts.min_width or 30, built.min_width or 30)
+    existing.user_opts = user_opts
+    existing.request_state = request_state
+    existing.border = user_opts.border or existing.border
+    existing.origin_win = origin_win
     if existing.selected and existing.selected > #built.actions then
       existing.selected = nil
     end
@@ -103,7 +112,6 @@ M.open = function(results_lsp, user_opts)
   if border_style == '' then
     border_style = nil
   end
-  local origin_win = vim.api.nvim_get_current_win()
 
   local buf = window.create_scratch_buf({
     filetype = 'cosmicui-codeactions',
@@ -167,7 +175,7 @@ M.open = function(results_lsp, user_opts)
     ns = lifecycle.ensure_namespace('cosmic-ui-codeactions'),
   }
 
-  lifecycle.attach_close_autocmds(ui, dismiss_current)
+  lifecycle.attach_close_autocmds(ui, close_current)
   lifecycle.set_ui(ui)
 
   local handlers = {
@@ -175,7 +183,8 @@ M.open = function(results_lsp, user_opts)
   }
 
   local deps = {
-    close_fn = dismiss_current,
+    close_fn = close_current,
+    dismiss_fn = dismiss_current,
     render_fn = render.render,
   }
 

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -31,8 +31,6 @@ local function build_panel_model(built)
   end
 
   return panel.prepare({
-    title = built.title,
-    subtitle = built.subtitle,
     rows = built.rows,
     footer = footer,
     selected = (#built.actions > 0) and 1 or nil,

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -24,10 +24,6 @@ local function build_panel_model(built)
     { key = 'Esc', text = 'close' },
   }
 
-  if #built.actions > 0 and #built.actions <= 9 then
-    table.insert(footer, 2, { key = '1-9', text = 'pick' })
-  end
-
   if #built.actions == 0 then
     footer = {
       { key = 'Esc', text = 'close' },

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -19,20 +19,8 @@ local function dismiss_current()
 end
 
 local function build_panel_model(built)
-  local footer = {
-    { key = 'Enter', text = 'apply' },
-    { key = 'Esc', text = 'close' },
-  }
-
-  if #built.actions == 0 then
-    footer = {
-      { key = 'Esc', text = 'close' },
-    }
-  end
-
   return panel.prepare({
     rows = built.rows,
-    footer = footer,
     selected = (#built.actions > 0) and 1 or nil,
   })
 end

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -181,6 +181,12 @@ M.open = function(results_lsp, user_opts)
 
   input.set_keymaps(ui, handlers, deps)
   render.render(ui)
+
+  vim.api.nvim_buf_call(buf, function()
+    if vim.fn.mode() ~= 'n' then
+      vim.api.nvim_input('<Esc>')
+    end
+  end)
 end
 
 M.close = dismiss_current

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -1,4 +1,5 @@
 local utils = require('cosmic-ui.utils')
+local panel = require('cosmic-ui.ui.panel')
 local window = require('cosmic-ui.window')
 local transform = require('cosmic-ui.codeactions.transform')
 local lifecycle = require('cosmic-ui.codeactions.ui.lifecycle')
@@ -9,17 +10,29 @@ local logger = utils.Logger
 
 local M = {}
 
-local function compute_content_width(rows, min_width)
-  local width = math.max(min_width or 30, 30)
-  for _, row in ipairs(rows) do
-    width = math.max(width, vim.fn.strdisplaywidth(row.text))
-  end
-  return width
-end
+local function build_panel_model(built)
+  local footer = {
+    { key = 'Enter', text = 'apply' },
+    { key = 'Esc', text = 'close' },
+  }
 
-local function compute_height(row_count)
-  local max_height = math.max(8, math.floor((vim.o.lines - vim.o.cmdheight) * 0.7))
-  return math.max(1, math.min(row_count, max_height))
+  if #built.actions > 0 and #built.actions <= 9 then
+    table.insert(footer, 2, { key = '1-9', text = 'pick' })
+  end
+
+  if #built.actions == 0 then
+    footer = {
+      { key = 'Esc', text = 'close' },
+    }
+  end
+
+  return panel.prepare({
+    title = built.title,
+    subtitle = built.subtitle,
+    rows = built.rows,
+    footer = footer,
+    selected = (#built.actions > 0) and 1 or nil,
+  })
 end
 
 local function submit_action(action)
@@ -53,16 +66,21 @@ local function submit_action(action)
 end
 
 M.open = function(results_lsp, user_opts)
-  if not results_lsp or next(results_lsp) == nil then
+  if not results_lsp then
     logger:warn('No results from textDocument/codeAction')
     return
   end
 
-  lifecycle.close_current()
-
   local built = model.build(results_lsp)
-  if #built.actions == 0 then
-    logger:log('No code actions available')
+  local existing = lifecycle.get_state().ui
+
+  if existing and vim.api.nvim_buf_is_valid(existing.buf) and vim.api.nvim_win_is_valid(existing.win) then
+    existing.model = built
+    existing.panel = build_panel_model(built)
+    if existing.selected and existing.selected > #built.actions then
+      existing.selected = nil
+    end
+    render.render(existing)
     return
   end
 
@@ -71,9 +89,7 @@ M.open = function(results_lsp, user_opts)
   if border_style == '' then
     border_style = nil
   end
-  local content_width = compute_content_width(built.rows, user_opts.min_width or built.min_width)
-  local width = content_width + 2
-  local height = compute_height(#built.rows)
+  local origin_win = vim.api.nvim_get_current_win()
 
   local buf = window.create_scratch_buf({
     filetype = 'cosmicui-codeactions',
@@ -88,13 +104,9 @@ M.open = function(results_lsp, user_opts)
     relative = 'cursor',
     row = 1,
     col = 0,
-    width = width,
-    height = height,
+    width = 30,
+    height = 1,
     border = border_style,
-    title = border.title,
-    title_pos = border.title_align,
-    footer = '(1/' .. tostring(#built.actions) .. ')',
-    footer_pos = 'right',
   })
   if not win then
     window.safe_delete_buf(buf, { force = true })
@@ -112,12 +124,7 @@ M.open = function(results_lsp, user_opts)
   if border.highlight then
     table.insert(winhl, 'FloatBorder:' .. border.highlight)
   end
-  if border.title_hl then
-    table.insert(winhl, 'FloatTitle:' .. border.title_hl)
-  end
-  if border.bottom_hl then
-    table.insert(winhl, 'FloatFooter:' .. border.bottom_hl)
-  end
+  table.insert(winhl, 'CursorLine:Visual')
   if #winhl > 0 then
     vim.wo[win].winhl = table.concat(winhl, ',')
   end
@@ -128,11 +135,12 @@ M.open = function(results_lsp, user_opts)
     row = 1,
     col = 0,
     model = built,
-    selected = 1,
+    panel = build_panel_model(built),
+    selected = (#built.actions > 0) and 1 or nil,
     user_opts = user_opts,
     border = border,
-    ns = vim.api.nvim_create_namespace('cosmic-ui-codeactions'),
-    content_width = content_width,
+    origin_win = origin_win,
+    ns = lifecycle.ensure_namespace('cosmic-ui-codeactions'),
   }
 
   lifecycle.attach_close_autocmds(ui, lifecycle.close_current)
@@ -149,12 +157,6 @@ M.open = function(results_lsp, user_opts)
 
   input.set_keymaps(ui, handlers, deps)
   render.render(ui)
-
-  vim.api.nvim_buf_call(buf, function()
-    if vim.fn.mode() ~= 'n' then
-      vim.api.nvim_input('<Esc>')
-    end
-  end)
 end
 
 M.close = lifecycle.close_current

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -71,12 +71,14 @@ M.open = function(results_lsp, user_opts)
     return
   end
 
+  user_opts = user_opts or {}
   local built = model.build(results_lsp)
   local existing = lifecycle.get_state().ui
 
   if existing and vim.api.nvim_buf_is_valid(existing.buf) and vim.api.nvim_win_is_valid(existing.win) then
     existing.model = built
     existing.panel = build_panel_model(built)
+    existing.min_width = math.max(existing.min_width or 30, built.min_width or 30)
     if existing.selected and existing.selected > #built.actions then
       existing.selected = nil
     end
@@ -104,9 +106,11 @@ M.open = function(results_lsp, user_opts)
     relative = 'cursor',
     row = 1,
     col = 0,
-    width = 30,
+    width = math.max((user_opts.min_width or built.min_width or 30) + 2, 32),
     height = 1,
     border = border_style,
+    title = border.title,
+    title_pos = border.title_align,
   })
   if not win then
     window.safe_delete_buf(buf, { force = true })
@@ -124,6 +128,12 @@ M.open = function(results_lsp, user_opts)
   if border.highlight then
     table.insert(winhl, 'FloatBorder:' .. border.highlight)
   end
+  if border.title_hl then
+    table.insert(winhl, 'FloatTitle:' .. border.title_hl)
+  end
+  if border.bottom_hl then
+    table.insert(winhl, 'FloatFooter:' .. border.bottom_hl)
+  end
   table.insert(winhl, 'CursorLine:Visual')
   if #winhl > 0 then
     vim.wo[win].winhl = table.concat(winhl, ',')
@@ -137,6 +147,7 @@ M.open = function(results_lsp, user_opts)
     model = built,
     panel = build_panel_model(built),
     selected = (#built.actions > 0) and 1 or nil,
+    min_width = math.max(user_opts.min_width or 30, built.min_width or 30),
     user_opts = user_opts,
     border = border,
     origin_win = origin_win,

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -168,6 +168,7 @@ M.open = function(results_lsp, user_opts)
     close_fn = close_current,
     dismiss_fn = dismiss_current,
     render_fn = render.render,
+    update_selection_fn = render.update_selection,
   }
 
   input.set_keymaps(ui, handlers, deps)

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -71,6 +71,14 @@ M.open = function(results_lsp, user_opts)
     return
   end
 
+  local request_state = nil
+  if type(results_lsp) == 'table' and results_lsp.responses then
+    request_state = results_lsp
+    if lifecycle.is_request_dismissed(request_state) then
+      return
+    end
+  end
+
   user_opts = user_opts or {}
   local built = model.build(results_lsp)
   local existing = lifecycle.get_state().ui
@@ -149,6 +157,7 @@ M.open = function(results_lsp, user_opts)
     selected = (#built.actions > 0) and 1 or nil,
     min_width = math.max(user_opts.min_width or 30, built.min_width or 30),
     user_opts = user_opts,
+    request_state = request_state,
     border = border,
     origin_win = origin_win,
     ns = lifecycle.ensure_namespace('cosmic-ui-codeactions'),
@@ -162,7 +171,9 @@ M.open = function(results_lsp, user_opts)
   }
 
   local deps = {
-    close_fn = lifecycle.close_current,
+    close_fn = function()
+      lifecycle.close_current({ dismissed = true })
+    end,
     render_fn = render.render,
   }
 
@@ -170,6 +181,8 @@ M.open = function(results_lsp, user_opts)
   render.render(ui)
 end
 
-M.close = lifecycle.close_current
+M.close = function()
+  lifecycle.close_current({ dismissed = true })
+end
 
 return M

--- a/lua/cosmic-ui/codeactions/ui/init.lua
+++ b/lua/cosmic-ui/codeactions/ui/init.lua
@@ -10,6 +10,10 @@ local logger = utils.Logger
 
 local M = {}
 
+local function dismiss_current()
+  lifecycle.close_current({ dismissed = true })
+end
+
 local function build_panel_model(built)
   local footer = {
     { key = 'Enter', text = 'apply' },
@@ -163,7 +167,7 @@ M.open = function(results_lsp, user_opts)
     ns = lifecycle.ensure_namespace('cosmic-ui-codeactions'),
   }
 
-  lifecycle.attach_close_autocmds(ui, lifecycle.close_current)
+  lifecycle.attach_close_autocmds(ui, dismiss_current)
   lifecycle.set_ui(ui)
 
   local handlers = {
@@ -171,9 +175,7 @@ M.open = function(results_lsp, user_opts)
   }
 
   local deps = {
-    close_fn = function()
-      lifecycle.close_current({ dismissed = true })
-    end,
+    close_fn = dismiss_current,
     render_fn = render.render,
   }
 
@@ -181,8 +183,6 @@ M.open = function(results_lsp, user_opts)
   render.render(ui)
 end
 
-M.close = function()
-  lifecycle.close_current({ dismissed = true })
-end
+M.close = dismiss_current
 
 return M

--- a/lua/cosmic-ui/codeactions/ui/input.lua
+++ b/lua/cosmic-ui/codeactions/ui/input.lua
@@ -45,15 +45,6 @@ M.set_keymaps = function(ui, handlers, deps)
     handlers.submit_action(action)
   end
 
-  local function submit_index(index)
-    if not ui.model.actions[index] then
-      return
-    end
-
-    ui.selected = index
-    submit()
-  end
-
   map('n', 'j', function()
     move(1)
   end)
@@ -79,12 +70,6 @@ M.set_keymaps = function(ui, handlers, deps)
 
   map('n', '<Esc>', dismiss)
   map('n', '<C-c>', dismiss)
-
-  for idx = 1, 9 do
-    map('n', tostring(idx), function()
-      submit_index(idx)
-    end)
-  end
 end
 
 return M

--- a/lua/cosmic-ui/codeactions/ui/input.lua
+++ b/lua/cosmic-ui/codeactions/ui/input.lua
@@ -43,6 +43,15 @@ M.set_keymaps = function(ui, handlers, deps)
     handlers.submit_action(action)
   end
 
+  local function submit_index(index)
+    if not ui.model.actions[index] then
+      return
+    end
+
+    ui.selected = index
+    submit()
+  end
+
   map('n', 'j', function()
     move(1)
   end)
@@ -68,6 +77,12 @@ M.set_keymaps = function(ui, handlers, deps)
 
   map('n', '<Esc>', deps.close_fn)
   map('n', '<C-c>', deps.close_fn)
+
+  for idx = 1, 9 do
+    map('n', tostring(idx), function()
+      submit_index(idx)
+    end)
+  end
 end
 
 return M

--- a/lua/cosmic-ui/codeactions/ui/input.lua
+++ b/lua/cosmic-ui/codeactions/ui/input.lua
@@ -21,6 +21,8 @@ M.set_keymaps = function(ui, handlers, deps)
     vim.keymap.set(mode, lhs, rhs, { buffer = ui.buf, silent = true, nowait = true })
   end
 
+  local dismiss = deps.dismiss_fn or deps.close_fn
+
   local function move(step)
     local idx = next_index(ui, step)
     if not idx then
@@ -75,8 +77,8 @@ M.set_keymaps = function(ui, handlers, deps)
   map('n', '<CR>', submit)
   map('n', '<Space>', submit)
 
-  map('n', '<Esc>', deps.close_fn)
-  map('n', '<C-c>', deps.close_fn)
+  map('n', '<Esc>', dismiss)
+  map('n', '<C-c>', dismiss)
 
   for idx = 1, 9 do
     map('n', tostring(idx), function()

--- a/lua/cosmic-ui/codeactions/ui/input.lua
+++ b/lua/cosmic-ui/codeactions/ui/input.lua
@@ -29,7 +29,10 @@ M.set_keymaps = function(ui, handlers, deps)
       return
     end
     ui.selected = idx
-    deps.render_fn(ui)
+    local update_selection = deps.update_selection_fn or deps.render_fn
+    if update_selection then
+      update_selection(ui)
+    end
   end
 
   local function submit()

--- a/lua/cosmic-ui/codeactions/ui/lifecycle.lua
+++ b/lua/cosmic-ui/codeactions/ui/lifecycle.lua
@@ -34,7 +34,7 @@ M.close_current = function(opts)
   end
 
   opts = opts or {}
-  if opts.dismissed and ui.request_state and ui.request_state.status == 'loading' then
+  if opts.dismissed ~= false and ui.request_state and ui.request_state.status == 'loading' then
     ui_state.dismissed_request = ui.request_state
   end
 

--- a/lua/cosmic-ui/codeactions/ui/lifecycle.lua
+++ b/lua/cosmic-ui/codeactions/ui/lifecycle.lua
@@ -4,6 +4,7 @@ local M = {}
 
 local ui_state = {
   ui = nil,
+  ns = nil,
 }
 
 M.get_state = function()
@@ -12,6 +13,13 @@ end
 
 M.set_ui = function(ui)
   ui_state.ui = ui
+end
+
+M.ensure_namespace = function(name)
+  if not ui_state.ns then
+    ui_state.ns = vim.api.nvim_create_namespace(name or 'cosmic-ui-codeactions')
+  end
+  return ui_state.ns
 end
 
 M.close_current = function()
@@ -28,6 +36,7 @@ M.close_current = function()
 
   window.safe_close_win(ui.win)
   window.safe_delete_buf(ui.buf, { force = true })
+  window.restore_focus(ui.origin_win)
 end
 
 M.attach_close_autocmds = function(ui, close_fn)

--- a/lua/cosmic-ui/codeactions/ui/lifecycle.lua
+++ b/lua/cosmic-ui/codeactions/ui/lifecycle.lua
@@ -34,7 +34,7 @@ M.close_current = function(opts)
   end
 
   opts = opts or {}
-  if opts.dismissed ~= false and ui.request_state and ui.request_state.status == 'loading' then
+  if opts.dismissed == true and ui.request_state and ui.request_state.status == 'loading' then
     ui_state.dismissed_request = ui.request_state
   end
 

--- a/lua/cosmic-ui/codeactions/ui/lifecycle.lua
+++ b/lua/cosmic-ui/codeactions/ui/lifecycle.lua
@@ -3,6 +3,7 @@ local window = require('cosmic-ui.window')
 local M = {}
 
 local ui_state = {
+  dismissed_request = nil,
   ui = nil,
   ns = nil,
 }
@@ -15,6 +16,10 @@ M.set_ui = function(ui)
   ui_state.ui = ui
 end
 
+M.is_request_dismissed = function(request_state)
+  return request_state ~= nil and ui_state.dismissed_request == request_state
+end
+
 M.ensure_namespace = function(name)
   if not ui_state.ns then
     ui_state.ns = vim.api.nvim_create_namespace(name or 'cosmic-ui-codeactions')
@@ -22,10 +27,15 @@ M.ensure_namespace = function(name)
   return ui_state.ns
 end
 
-M.close_current = function()
+M.close_current = function(opts)
   local ui = ui_state.ui
   if not ui then
     return
+  end
+
+  opts = opts or {}
+  if opts.dismissed and ui.request_state and ui.request_state.status == 'loading' then
+    ui_state.dismissed_request = ui.request_state
   end
 
   ui_state.ui = nil

--- a/lua/cosmic-ui/codeactions/ui/model.lua
+++ b/lua/cosmic-ui/codeactions/ui/model.lua
@@ -1,16 +1,70 @@
+local states = require('cosmic-ui.ui.states')
+
 local M = {}
 
 local function sanitize_title(title)
   return title:gsub('\r\n', '\\r\\n'):gsub('\n', '\\n')
 end
 
+local function pluralize(count, singular, plural)
+  if count == 1 then
+    return ('1 %s'):format(singular)
+  end
+
+  return ('%d %s'):format(count, plural)
+end
+
+local function extract_request_state(results_lsp)
+  if type(results_lsp) == 'table' and results_lsp.responses then
+    return {
+      status = results_lsp.status or 'ready',
+      responses = results_lsp.responses,
+      total_clients = results_lsp.total_clients or 0,
+      completed_clients = results_lsp.completed_clients or 0,
+    }
+  end
+
+  return {
+    status = 'ready',
+    responses = results_lsp or {},
+    total_clients = 0,
+    completed_clients = 0,
+  }
+end
+
+local function push_row(rows, row, min_width)
+  table.insert(rows, row)
+  return math.max(min_width, vim.fn.strdisplaywidth(row.text or ''), 30)
+end
+
 M.build = function(results_lsp)
+  local request_state = extract_request_state(results_lsp)
   local rows = {}
   local actions = {}
-  local min_width = 0
+  local min_width = 30
+  local error_count = 0
+
+  if request_state.status == 'loading' then
+    local loading_text = 'Loading code actions...'
+    return {
+      rows = {
+        { kind = 'state', state = 'info', text = loading_text },
+      },
+      actions = actions,
+      min_width = math.max(min_width, vim.fn.strdisplaywidth(loading_text)),
+      title = 'Code Actions',
+      subtitle = 'Loading...',
+      has_partial_error = false,
+      error_count = 0,
+    }
+  end
 
   local sorted_responses = {}
-  for _, response in pairs(results_lsp or {}) do
+  for _, response in pairs(request_state.responses or {}) do
+    if response.error then
+      error_count = error_count + 1
+    end
+
     if response.result and next(response.result) ~= nil then
       table.insert(sorted_responses, response)
     end
@@ -32,10 +86,10 @@ M.build = function(results_lsp)
   for _, response in ipairs(sorted_responses) do
     local client = response.client
     if client and client.name then
-      table.insert(rows, {
-        kind = 'separator',
-        text = '(' .. client.name .. ')',
-      })
+      min_width = push_row(rows, {
+        kind = 'section',
+        text = client.name,
+      }, min_width)
 
       for _, result in ipairs(response.result) do
         local command_title = sanitize_title(result.title or '')
@@ -46,17 +100,41 @@ M.build = function(results_lsp)
           command = result,
         }
 
-        min_width = math.max(min_width, #command_title, 30)
+        min_width = math.max(min_width, vim.fn.strdisplaywidth(command_title), 30)
         table.insert(rows, action)
         table.insert(actions, action)
       end
     end
   end
 
+  local has_partial_error = error_count > 0 and #actions > 0
+
+  if #actions == 0 then
+    if error_count > 0 then
+      local error_text = pluralize(error_count, 'code action request failed', 'code action requests failed')
+      rows = {
+        { kind = 'state', state = 'error', text = error_text },
+      }
+      min_width = math.max(min_width, vim.fn.strdisplaywidth(error_text), 30)
+    else
+      local empty_row = states.empty('No code actions available')
+      rows = { empty_row }
+      min_width = math.max(min_width, vim.fn.strdisplaywidth(empty_row.text), 30)
+    end
+  elseif has_partial_error then
+    local warning_text = pluralize(error_count, 'source failed to return code actions', 'sources failed to return code actions')
+    table.insert(rows, 1, { kind = 'state', state = 'warn', text = warning_text })
+    min_width = math.max(min_width, vim.fn.strdisplaywidth(warning_text), 30)
+  end
+
   return {
     rows = rows,
     actions = actions,
     min_width = min_width,
+    title = 'Code Actions',
+    subtitle = ('%s actions'):format(#actions),
+    has_partial_error = has_partial_error,
+    error_count = error_count,
   }
 end
 

--- a/lua/cosmic-ui/codeactions/ui/model.lua
+++ b/lua/cosmic-ui/codeactions/ui/model.lua
@@ -122,7 +122,8 @@ M.build = function(results_lsp)
       min_width = math.max(min_width, vim.fn.strdisplaywidth(empty_row.text), 30)
     end
   elseif has_partial_error then
-    local warning_text = pluralize(error_count, 'source failed to return code actions', 'sources failed to return code actions')
+    local warning_text =
+      pluralize(error_count, 'source failed to return code actions', 'sources failed to return code actions')
     table.insert(rows, 1, { kind = 'state', state = 'warn', text = warning_text })
     min_width = math.max(min_width, vim.fn.strdisplaywidth(warning_text), 30)
   end

--- a/lua/cosmic-ui/codeactions/ui/model.lua
+++ b/lua/cosmic-ui/codeactions/ui/model.lua
@@ -52,8 +52,6 @@ M.build = function(results_lsp)
       },
       actions = actions,
       min_width = math.max(min_width, vim.fn.strdisplaywidth(loading_text)),
-      title = 'Code Actions',
-      subtitle = 'Loading...',
       has_partial_error = false,
       error_count = 0,
     }
@@ -132,8 +130,6 @@ M.build = function(results_lsp)
     rows = rows,
     actions = actions,
     min_width = min_width,
-    title = 'Code Actions',
-    subtitle = ('%s actions'):format(#actions),
     has_partial_error = has_partial_error,
     error_count = error_count,
   }

--- a/lua/cosmic-ui/codeactions/ui/render.lua
+++ b/lua/cosmic-ui/codeactions/ui/render.lua
@@ -95,8 +95,7 @@ M.render = function(ui)
       push_line(' ' .. row.text .. ' ', { highlight = row.highlight or 'CosmicUiPanelStateInfo' })
     elseif row.kind == 'action' then
       action_idx = action_idx + 1
-      local prefix = (#ui.model.actions <= 9) and (tostring(action_idx) .. '. ') or ''
-      push_line(' ' .. prefix .. row.text .. ' ')
+      push_line(' ' .. row.text .. ' ')
       action_line_by_idx[action_idx] = #lines
     else
       push_line(' ' .. (row.text or '') .. ' ')

--- a/lua/cosmic-ui/codeactions/ui/render.lua
+++ b/lua/cosmic-ui/codeactions/ui/render.lua
@@ -9,28 +9,33 @@ end
 local function footer_line(entries)
   local text = ''
   local spans = {}
+  local col = 0
 
   for idx, entry in ipairs(entries or {}) do
     if idx > 1 then
       text = text .. '  '
+      col = col + 2
     end
 
-    local key_start = #text + 1
-    text = text .. entry.key
-    local key_end = #text
+    local key = entry.key or ''
+    local hint = entry.text or ''
+
+    text = text .. key
     table.insert(spans, {
       highlight = entry.key_highlight,
-      start_col = key_start,
-      end_col = key_end,
+      start_col = col,
+      end_col = col + #key,
     })
+    col = col + #key
 
-    if entry.text ~= '' then
-      text = text .. ':' .. entry.text
+    if hint ~= '' then
+      text = text .. ':' .. hint
       table.insert(spans, {
         highlight = entry.text_highlight,
-        start_col = key_end + 2,
-        end_col = #text,
+        start_col = col + 1,
+        end_col = col + 1 + #hint,
       })
+      col = col + 1 + #hint
     end
   end
 

--- a/lua/cosmic-ui/codeactions/ui/render.lua
+++ b/lua/cosmic-ui/codeactions/ui/render.lua
@@ -63,58 +63,104 @@ M.render = function(ui)
   M.ensure_selection(ui)
 
   local panel = ui.panel or {}
-  local lines = {}
-  local highlights = {}
+  local line_specs = {}
   local action_line_by_idx = {}
-  local max_width = 30
+  local raw_max_width = 30
   local action_idx = 0
+  local seen_section = false
 
-  local function push_line(text, meta)
-    table.insert(lines, text)
-    if meta then
-      highlights[#lines] = meta
-    end
-    max_width = math.max(max_width, vim.fn.strdisplaywidth(text))
+  local function push_line(spec)
+    spec = spec or { text = '' }
+    table.insert(line_specs, spec)
+    raw_max_width = math.max(raw_max_width, vim.fn.strdisplaywidth(spec.text or ''))
   end
 
   if panel.title and panel.title ~= '' then
-    push_line(' ' .. panel.title .. ' ', { highlight = panel.title_highlight or 'CosmicUiPanelTitle' })
+    push_line({
+      text = ' ' .. panel.title .. ' ',
+      meta = { highlight = panel.title_highlight or 'CosmicUiPanelTitle' },
+    })
   end
   if panel.subtitle and panel.subtitle ~= '' then
-    push_line(' ' .. panel.subtitle .. ' ', { highlight = panel.subtitle_highlight or 'CosmicUiPanelSubtitle' })
+    push_line({
+      text = ' ' .. panel.subtitle .. ' ',
+      meta = { highlight = panel.subtitle_highlight or 'CosmicUiPanelSubtitle' },
+    })
   end
 
-  if #lines > 0 and panel.rows and #panel.rows > 0 then
-    push_line('')
+  if #line_specs > 0 and panel.rows and #panel.rows > 0 then
+    push_line({ text = '' })
   end
 
   for _, row in ipairs(panel.rows or {}) do
     if row.kind == 'section' or row.kind == 'separator' then
-      push_line(' ' .. row.text .. ' ', { highlight = 'CosmicUiPanelSection' })
+      if seen_section then
+        push_line({ text = '' })
+      end
+      push_line({
+        text = row.text or '',
+        center = true,
+        meta = { highlight = 'CosmicUiPanelSection' },
+      })
+      seen_section = true
     elseif row.kind == 'state' then
-      push_line(' ' .. row.text .. ' ', { highlight = row.highlight or 'CosmicUiPanelStateInfo' })
+      push_line({
+        text = ' ' .. row.text .. ' ',
+        meta = { highlight = row.highlight or 'CosmicUiPanelStateInfo' },
+      })
     elseif row.kind == 'action' then
       action_idx = action_idx + 1
-      push_line(' ' .. row.text .. ' ')
-      action_line_by_idx[action_idx] = #lines
+      push_line({ text = ' ' .. row.text .. ' ' })
+      action_line_by_idx[action_idx] = #line_specs
     else
-      push_line(' ' .. (row.text or '') .. ' ')
+      push_line({ text = ' ' .. (row.text or '') .. ' ' })
     end
   end
 
   if panel.footer and #panel.footer > 0 then
-    if #lines > 0 then
-      push_line('')
+    if #line_specs > 0 then
+      push_line({ text = '' })
     end
     local footer_text, spans = footer_line(panel.footer)
     for _, span in ipairs(spans) do
       span.start_col = span.start_col + 1
       span.end_col = span.end_col + 1
     end
-    push_line(' ' .. footer_text .. ' ', { spans = spans })
+    push_line({
+      text = ' ' .. footer_text .. ' ',
+      meta = { spans = spans },
+    })
   end
 
-  local width, height = clamp_ui_size(math.max(max_width, (ui.min_width or 30) + 2), math.max(#lines, 1))
+  local width, height = clamp_ui_size(math.max(raw_max_width, (ui.min_width or 30) + 2), math.max(#line_specs, 1))
+
+  local lines = {}
+  local highlights = {}
+
+  local function finalize_text(spec)
+    local text = spec.text or ''
+    if not spec.center then
+      return text
+    end
+
+    local text_width = vim.fn.strdisplaywidth(text)
+    if text_width >= width then
+      return text
+    end
+
+    local total_padding = width - text_width
+    local left_padding = math.floor(total_padding / 2)
+    local right_padding = total_padding - left_padding
+    return string.rep(' ', left_padding) .. text .. string.rep(' ', right_padding)
+  end
+
+  for idx, spec in ipairs(line_specs) do
+    lines[idx] = finalize_text(spec)
+    if spec.meta then
+      highlights[idx] = spec.meta
+    end
+  end
+
   local indicator = nil
   if #ui.model.actions > 0 then
     indicator = ('(%d/%d)'):format(ui.selected or 0, #ui.model.actions)

--- a/lua/cosmic-ui/codeactions/ui/render.lua
+++ b/lua/cosmic-ui/codeactions/ui/render.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local function clamp_ui_size(width, height)
-  local max_width = math.max(36, math.floor(vim.o.columns * 0.6))
+  local max_width = math.max(36, math.floor(vim.o.columns * 0.9))
   local max_height = math.max(8, math.floor((vim.o.lines - vim.o.cmdheight) * 0.7))
   return math.min(width, max_width), math.min(height, max_height)
 end
@@ -110,12 +110,20 @@ M.render = function(ui)
     push_line(' ' .. footer_text .. ' ', { spans = spans })
   end
 
-  local width, height = clamp_ui_size(max_width, math.max(#lines, 1))
+  local width, height = clamp_ui_size(math.max(max_width, (ui.min_width or 30) + 2), math.max(#lines, 1))
+  local indicator = nil
+  if #ui.model.actions > 0 then
+    indicator = ('(%d/%d)'):format(ui.selected or 0, #ui.model.actions)
+  end
 
   if ui.win and vim.api.nvim_win_is_valid(ui.win) then
     local cfg = vim.api.nvim_win_get_config(ui.win)
     cfg.width = width
     cfg.height = height
+    cfg.title = ui.border and ui.border.title or nil
+    cfg.title_pos = ui.border and ui.border.title_align or nil
+    cfg.footer = indicator
+    cfg.footer_pos = indicator and 'right' or nil
     vim.api.nvim_win_set_config(ui.win, cfg)
   end
 

--- a/lua/cosmic-ui/codeactions/ui/render.lua
+++ b/lua/cosmic-ui/codeactions/ui/render.lua
@@ -1,41 +1,53 @@
 local M = {}
 
-local function pad_right(text, width)
-  local text_width = vim.fn.strdisplaywidth(text)
-  if text_width >= width then
-    return text
-  end
-  return text .. string.rep(' ', width - text_width)
+local function clamp_ui_size(width, height)
+  local max_width = math.max(36, math.floor(vim.o.columns * 0.6))
+  local max_height = math.max(8, math.floor((vim.o.lines - vim.o.cmdheight) * 0.7))
+  return math.min(width, max_width), math.min(height, max_height)
 end
 
-local function bordered_header(text, width)
-  local label = text
-  local label_width = vim.fn.strdisplaywidth(label)
-  if label_width >= width then
-    return label, 0, #label
+local function footer_line(entries)
+  local text = ''
+  local spans = {}
+
+  for idx, entry in ipairs(entries or {}) do
+    if idx > 1 then
+      text = text .. '  '
+    end
+
+    local key_start = #text + 1
+    text = text .. entry.key
+    local key_end = #text
+    table.insert(spans, {
+      highlight = entry.key_highlight,
+      start_col = key_start,
+      end_col = key_end,
+    })
+
+    if entry.text ~= '' then
+      text = text .. ':' .. entry.text
+      table.insert(spans, {
+        highlight = entry.text_highlight,
+        start_col = key_end + 2,
+        end_col = #text,
+      })
+    end
   end
 
-  -- Draw a simple section divider line: "──── (client) ────"
-  local pad = width - label_width
-  local left = math.floor(pad / 2)
-  local right = pad - left
-
-  local left_fill = (left > 0) and (string.rep('─', math.max(left - 1, 0)) .. ' ') or ''
-  local right_fill = (right > 0) and (' ' .. string.rep('─', math.max(right - 1, 0))) or ''
-  local rendered = left_fill .. label .. right_fill
-  local label_start = #left_fill
-  local label_end = label_start + #label
-  return rendered, label_start, label_end
+  return text, spans
 end
 
-local function next_selected(ui)
-  if ui.selected and ui.selected >= 1 and ui.selected <= #ui.model.actions then
-    return ui.selected
-  end
+M.ensure_selection = function(ui)
   if #ui.model.actions == 0 then
-    return nil
+    ui.selected = nil
+    return
   end
-  return 1
+
+  if ui.selected and ui.selected >= 1 and ui.selected <= #ui.model.actions then
+    return
+  end
+
+  ui.selected = 1
 end
 
 M.render = function(ui)
@@ -43,50 +55,68 @@ M.render = function(ui)
     return
   end
 
-  ui.selected = next_selected(ui)
+  M.ensure_selection(ui)
 
-  local indicator = ('(%d/%d)'):format(ui.selected or 0, #ui.model.actions)
-  local content_width = math.max(ui.content_width or 30, vim.fn.strdisplaywidth(indicator), 30)
-
+  local panel = ui.panel or {}
   local lines = {}
-  local line_meta = {}
+  local highlights = {}
   local action_line_by_idx = {}
+  local max_width = 30
   local action_idx = 0
 
-  for _, row in ipairs(ui.model.rows) do
-    local line_text = row.text
-    local label_start_col = nil
-    local label_end_col = nil
-    if row.kind == 'separator' then
-      line_text, label_start_col, label_end_col = bordered_header(line_text, content_width)
-    else
-      line_text = pad_right(line_text, content_width)
+  local function push_line(text, meta)
+    table.insert(lines, text)
+    if meta then
+      highlights[#lines] = meta
     end
-    local padded = ' ' .. line_text .. ' '
-    table.insert(lines, padded)
+    max_width = math.max(max_width, vim.fn.strdisplaywidth(text))
+  end
 
-    local line_no = #lines
-    if row.kind == 'action' then
+  if panel.title and panel.title ~= '' then
+    push_line(' ' .. panel.title .. ' ', { highlight = panel.title_highlight or 'CosmicUiPanelTitle' })
+  end
+  if panel.subtitle and panel.subtitle ~= '' then
+    push_line(' ' .. panel.subtitle .. ' ', { highlight = panel.subtitle_highlight or 'CosmicUiPanelSubtitle' })
+  end
+
+  if #lines > 0 and panel.rows and #panel.rows > 0 then
+    push_line('')
+  end
+
+  for _, row in ipairs(panel.rows or {}) do
+    if row.kind == 'section' or row.kind == 'separator' then
+      push_line(' ' .. row.text .. ' ', { highlight = 'CosmicUiPanelSection' })
+    elseif row.kind == 'state' then
+      push_line(' ' .. row.text .. ' ', { highlight = row.highlight or 'CosmicUiPanelStateInfo' })
+    elseif row.kind == 'action' then
       action_idx = action_idx + 1
-      action_line_by_idx[action_idx] = line_no
-      line_meta[line_no] = { kind = 'action', action_idx = action_idx }
+      local prefix = (#ui.model.actions <= 9) and (tostring(action_idx) .. '. ') or ''
+      push_line(' ' .. prefix .. row.text .. ' ')
+      action_line_by_idx[action_idx] = #lines
     else
-      local label_start = (label_start_col or 0) + 1 -- account for left padding space
-      local label_end = (label_end_col or 0) + 1
-      local name_start = label_start
-      local name_end = label_end
-
-      if vim.startswith(row.text, '(') and row.text:sub(-1) == ')' then
-        name_start = label_start + 1
-        name_end = label_end - 1
-      end
-
-      line_meta[line_no] = {
-        kind = 'separator',
-        name_start_col = name_start,
-        name_end_col = name_end,
-      }
+      push_line(' ' .. (row.text or '') .. ' ')
     end
+  end
+
+  if panel.footer and #panel.footer > 0 then
+    if #lines > 0 then
+      push_line('')
+    end
+    local footer_text, spans = footer_line(panel.footer)
+    for _, span in ipairs(spans) do
+      span.start_col = span.start_col + 1
+      span.end_col = span.end_col + 1
+    end
+    push_line(' ' .. footer_text .. ' ', { spans = spans })
+  end
+
+  local width, height = clamp_ui_size(max_width, math.max(#lines, 1))
+
+  if ui.win and vim.api.nvim_win_is_valid(ui.win) then
+    local cfg = vim.api.nvim_win_get_config(ui.win)
+    cfg.width = width
+    cfg.height = height
+    vim.api.nvim_win_set_config(ui.win, cfg)
   end
 
   vim.bo[ui.buf].modifiable = true
@@ -95,29 +125,20 @@ M.render = function(ui)
 
   local ns = ui.ns
   vim.api.nvim_buf_clear_namespace(ui.buf, ns, 0, -1)
-  local separator_hl = ui.border and ui.border.highlight or 'FloatBorder'
-  if separator_hl == '' or separator_hl == nil then
-    separator_hl = 'FloatBorder'
-  end
 
-  for line_no, meta in pairs(line_meta) do
-    if meta.kind == 'separator' then
-      vim.api.nvim_buf_add_highlight(ui.buf, ns, separator_hl, line_no - 1, 0, -1)
-      if meta.name_end_col > meta.name_start_col then
-        vim.api.nvim_buf_add_highlight(ui.buf, ns, 'Comment', line_no - 1, meta.name_start_col, meta.name_end_col)
+  for line_no, meta in pairs(highlights) do
+    if meta.highlight then
+      vim.api.nvim_buf_add_highlight(ui.buf, ns, meta.highlight, line_no - 1, 0, -1)
+    end
+
+    for _, span in ipairs(meta.spans or {}) do
+      if span.end_col >= span.start_col then
+        vim.api.nvim_buf_add_highlight(ui.buf, ns, span.highlight, line_no - 1, span.start_col, span.end_col)
       end
     end
   end
 
   ui.action_line_by_idx = action_line_by_idx
-  ui.line_meta = line_meta
-
-  if ui.win and vim.api.nvim_win_is_valid(ui.win) then
-    local cfg = vim.api.nvim_win_get_config(ui.win)
-    cfg.footer = indicator
-    cfg.footer_pos = 'right'
-    vim.api.nvim_win_set_config(ui.win, cfg)
-  end
 
   if ui.selected and ui.action_line_by_idx[ui.selected] and ui.win and vim.api.nvim_win_is_valid(ui.win) then
     pcall(vim.api.nvim_win_set_cursor, ui.win, { ui.action_line_by_idx[ui.selected], 0 })

--- a/lua/cosmic-ui/codeactions/ui/render.lua
+++ b/lua/cosmic-ui/codeactions/ui/render.lua
@@ -1,3 +1,5 @@
+local panel = require('cosmic-ui.ui.panel')
+
 local M = {}
 
 local function clamp_ui_size(width, height)
@@ -6,40 +8,29 @@ local function clamp_ui_size(width, height)
   return math.min(width, max_width), math.min(height, max_height)
 end
 
-local function footer_line(entries)
-  local text = ''
-  local spans = {}
-  local col = 0
-
-  for idx, entry in ipairs(entries or {}) do
-    if idx > 1 then
-      text = text .. '  '
-      col = col + 2
-    end
-
-    local key = entry.key or ''
-    local hint = entry.text or ''
-
-    text = text .. key
-    table.insert(spans, {
-      highlight = entry.key_highlight,
-      start_col = col,
-      end_col = col + #key,
-    })
-    col = col + #key
-
-    if hint ~= '' then
-      text = text .. ':' .. hint
-      table.insert(spans, {
-        highlight = entry.text_highlight,
-        start_col = col + 1,
-        end_col = col + 1 + #hint,
-      })
-      col = col + 1 + #hint
-    end
+local function selection_indicator(ui)
+  if #ui.model.actions == 0 then
+    return nil
   end
 
-  return text, spans
+  return ('(%d/%d)'):format(ui.selected or 0, #ui.model.actions)
+end
+
+local function apply_selection(ui)
+  local indicator = selection_indicator(ui)
+
+  if ui.win and vim.api.nvim_win_is_valid(ui.win) then
+    vim.api.nvim_win_set_config(ui.win, {
+      footer = indicator,
+      footer_pos = indicator and 'right' or nil,
+    })
+  end
+
+  if ui.selected and ui.action_line_by_idx and ui.action_line_by_idx[ui.selected] and ui.win and vim.api.nvim_win_is_valid(
+      ui.win
+    ) then
+    pcall(vim.api.nvim_win_set_cursor, ui.win, { ui.action_line_by_idx[ui.selected], 0 })
+  end
 end
 
 M.ensure_selection = function(ui)
@@ -55,6 +46,15 @@ M.ensure_selection = function(ui)
   ui.selected = 1
 end
 
+M.update_selection = function(ui)
+  if not (ui.buf and vim.api.nvim_buf_is_valid(ui.buf)) then
+    return
+  end
+
+  M.ensure_selection(ui)
+  apply_selection(ui)
+end
+
 M.render = function(ui)
   if not (ui.buf and vim.api.nvim_buf_is_valid(ui.buf)) then
     return
@@ -62,109 +62,14 @@ M.render = function(ui)
 
   M.ensure_selection(ui)
 
-  local panel = ui.panel or {}
-  local line_specs = {}
-  local action_line_by_idx = {}
-  local raw_max_width = 30
-  local action_idx = 0
-  local seen_section = false
-
-  local function push_line(spec)
-    spec = spec or { text = '' }
-    table.insert(line_specs, spec)
-    raw_max_width = math.max(raw_max_width, vim.fn.strdisplaywidth(spec.text or ''))
-  end
-
-  if panel.title and panel.title ~= '' then
-    push_line({
-      text = ' ' .. panel.title .. ' ',
-      meta = { highlight = panel.title_highlight or 'CosmicUiPanelTitle' },
-    })
-  end
-  if panel.subtitle and panel.subtitle ~= '' then
-    push_line({
-      text = ' ' .. panel.subtitle .. ' ',
-      meta = { highlight = panel.subtitle_highlight or 'CosmicUiPanelSubtitle' },
-    })
-  end
-
-  if #line_specs > 0 and panel.rows and #panel.rows > 0 then
-    push_line({ text = '' })
-  end
-
-  for _, row in ipairs(panel.rows or {}) do
-    if row.kind == 'section' or row.kind == 'separator' then
-      if seen_section then
-        push_line({ text = '' })
-      end
-      push_line({
-        text = row.text or '',
-        center = true,
-        meta = { highlight = 'CosmicUiPanelSection' },
-      })
-      seen_section = true
-    elseif row.kind == 'state' then
-      push_line({
-        text = ' ' .. row.text .. ' ',
-        meta = { highlight = row.highlight or 'CosmicUiPanelStateInfo' },
-      })
-    elseif row.kind == 'action' then
-      action_idx = action_idx + 1
-      push_line({ text = ' ' .. row.text .. ' ' })
-      action_line_by_idx[action_idx] = #line_specs
-    else
-      push_line({ text = ' ' .. (row.text or '') .. ' ' })
-    end
-  end
-
-  if panel.footer and #panel.footer > 0 then
-    if #line_specs > 0 then
-      push_line({ text = '' })
-    end
-    local footer_text, spans = footer_line(panel.footer)
-    for _, span in ipairs(spans) do
-      span.start_col = span.start_col + 1
-      span.end_col = span.end_col + 1
-    end
-    push_line({
-      text = ' ' .. footer_text .. ' ',
-      meta = { spans = spans },
-    })
-  end
-
-  local width, height = clamp_ui_size(math.max(raw_max_width, (ui.min_width or 30) + 2), math.max(#line_specs, 1))
-
-  local lines = {}
-  local highlights = {}
-
-  local function finalize_text(spec)
-    local text = spec.text or ''
-    if not spec.center then
-      return text
-    end
-
-    local text_width = vim.fn.strdisplaywidth(text)
-    if text_width >= width then
-      return text
-    end
-
-    local total_padding = width - text_width
-    local left_padding = math.floor(total_padding / 2)
-    local right_padding = total_padding - left_padding
-    return string.rep(' ', left_padding) .. text .. string.rep(' ', right_padding)
-  end
-
-  for idx, spec in ipairs(line_specs) do
-    lines[idx] = finalize_text(spec)
-    if spec.meta then
-      highlights[idx] = spec.meta
-    end
-  end
-
-  local indicator = nil
-  if #ui.model.actions > 0 then
-    indicator = ('(%d/%d)'):format(ui.selected or 0, #ui.model.actions)
-  end
+  local prepared = panel.prepare_standard(ui.panel, {
+    min_width = ui.min_width or 30,
+    clamp_size = clamp_ui_size,
+  })
+  local width = prepared.width
+  local height = prepared.height
+  local lines = prepared.lines
+  local highlights = prepared.highlights
 
   if ui.win and vim.api.nvim_win_is_valid(ui.win) then
     local cfg = vim.api.nvim_win_get_config(ui.win)
@@ -172,8 +77,6 @@ M.render = function(ui)
     cfg.height = height
     cfg.title = ui.border and ui.border.title or nil
     cfg.title_pos = ui.border and ui.border.title_align or nil
-    cfg.footer = indicator
-    cfg.footer_pos = indicator and 'right' or nil
     vim.api.nvim_win_set_config(ui.win, cfg)
   end
 
@@ -196,11 +99,8 @@ M.render = function(ui)
     end
   end
 
-  ui.action_line_by_idx = action_line_by_idx
-
-  if ui.selected and ui.action_line_by_idx[ui.selected] and ui.win and vim.api.nvim_win_is_valid(ui.win) then
-    pcall(vim.api.nvim_win_set_cursor, ui.win, { ui.action_line_by_idx[ui.selected], 0 })
-  end
+  ui.action_line_by_idx = prepared.action_line_by_idx
+  M.update_selection(ui)
 end
 
 return M

--- a/lua/cosmic-ui/config.lua
+++ b/lua/cosmic-ui/config.lua
@@ -107,9 +107,7 @@ end
 
 M.warn_not_setup = function(method_name)
   warn_once(
-    ('cosmic-ui is not set up. Call require("cosmic-ui").setup({...}) before using CosmicUI.%s'):format(
-      method_name
-    )
+    ('cosmic-ui is not set up. Call require("cosmic-ui").setup({...}) before using CosmicUI.%s'):format(method_name)
   )
 end
 

--- a/lua/cosmic-ui/formatters/constants.lua
+++ b/lua/cosmic-ui/formatters/constants.lua
@@ -1,3 +1,5 @@
+local ui_constants = require('cosmic-ui.ui.constants')
+
 local M = {}
 
 M.default_backend_state = {
@@ -11,19 +13,15 @@ M.status_icons = {
   unavailable = '',
 }
 
-M.ui_padding = {
-  x = 1,
-  y = 0,
-}
+M.ui_padding = ui_constants.padding
 
 M.highlight_links = {
-  CosmicUiFmtTitle = 'Title',
+  CosmicUiFmtTitle = 'CosmicUiPanelTitle',
   CosmicUiFmtHeader = 'Identifier',
-  CosmicUiFmtSection = 'Type',
+  CosmicUiFmtSection = 'CosmicUiPanelSection',
+  CosmicUiFmtSubtitle = 'CosmicUiPanelSubtitle',
   CosmicUiFmtCursorLine = 'CursorLine',
   CosmicUiFmtCursor = 'Cursor',
-  CosmicUiFmtHintKey = 'Special',
-  CosmicUiFmtHintText = 'Comment',
   CosmicUiFmtEnabled = 'String',
   CosmicUiFmtDisabled = 'Comment',
   CosmicUiFmtUnavailable = 'WarningMsg',

--- a/lua/cosmic-ui/formatters/normalize.lua
+++ b/lua/cosmic-ui/formatters/normalize.lua
@@ -23,9 +23,7 @@ M.resolve_bufnr = function(bufnr)
   end
 
   if type(resolved) ~= 'number' then
-    logger:warn(
-      ('Invalid formatter bufnr type `%s`; expected an integer buffer handle.'):format(type(resolved))
-    )
+    logger:warn(('Invalid formatter bufnr type `%s`; expected an integer buffer handle.'):format(type(resolved)))
     return nil
   end
 

--- a/lua/cosmic-ui/formatters/ui/highlights.lua
+++ b/lua/cosmic-ui/formatters/ui/highlights.lua
@@ -1,3 +1,5 @@
+local shared_highlights = require('cosmic-ui.ui.highlights')
+
 local M = {}
 
 local function find_token(line, token, init)
@@ -31,34 +33,12 @@ local function status_hl_group(status)
   return 'CosmicUiFmtUnavailable'
 end
 
-local function highlight_hint_keys(bufnr, ns, line_no, line)
-  local keys = {
-    { key = '<tab>', token = '<tab>:' },
-    { key = 's', token = 's:' },
-    { key = 'r', token = 'r:' },
-    { key = 'a', token = 'a:' },
-    { key = 'f', token = 'f:' },
-    { key = 'q', token = 'q:' },
-  }
-  add_hl(bufnr, ns, line_no, 'CosmicUiFmtHintText', 0, -1)
-
-  for _, entry in ipairs(keys) do
-    local start_at = 1
-    while true do
-      local s_col, e_col = find_token(line, entry.token, start_at)
-      if not s_col then
-        break
-      end
-      add_hl(bufnr, ns, line_no, 'CosmicUiFmtHintKey', s_col, s_col + #entry.key)
-      start_at = e_col + 1
-    end
-  end
-end
-
 M.ensure = function(state, highlight_links)
   if not state.ns then
     state.ns = vim.api.nvim_create_namespace('cosmic-ui-formatters')
   end
+
+  shared_highlights.ensure()
 
   for name, link in pairs(highlight_links) do
     if name ~= 'CosmicUiFmtCursorLine' then
@@ -100,7 +80,7 @@ M.apply = function(bufnr, ns, ui, lines)
 
   vim.api.nvim_buf_clear_namespace(bufnr, ns, 0, -1)
 
-  if ui.selected and ui.rows and ui.rows[ui.selected] then
+  if ui.selected and ui.rows and ui.rows[ui.selected] and lines[ui.rows[ui.selected].lnum] then
     local selected_row = ui.rows[ui.selected]
     add_hl(bufnr, ns, selected_row.lnum - 1, 'CosmicUiFmtCursorLine', 0, -1)
   end
@@ -114,36 +94,33 @@ M.apply = function(bufnr, ns, ui, lines)
 
   for _, row in ipairs(ui.rows) do
     local line = lines[row.lnum]
-    local lnum = row.lnum - 1
-    if row.kind == 'section' then
-      add_hl(bufnr, ns, lnum, 'CosmicUiFmtSection', 0, -1)
-      if row.ghost_text then
-        local ghost_start, ghost_end = find_token(line, row.ghost_text, 1)
-        add_hl(bufnr, ns, lnum, 'CosmicUiFmtHintText', ghost_start, ghost_end)
-      end
-    else
-      local status_start, status_end = find_token(line, row.status_icon, 1)
-      add_hl(bufnr, ns, lnum, status_hl_group(row.status), status_start, status_end)
+    if line then
+      local lnum = row.lnum - 1
+      if row.kind == 'section' then
+        add_hl(bufnr, ns, lnum, 'CosmicUiFmtSection', 0, -1)
+        if row.subtitle then
+          local subtitle_start, subtitle_end = find_token(line, row.subtitle, 1)
+          add_hl(bufnr, ns, lnum, 'CosmicUiFmtSubtitle', subtitle_start, subtitle_end)
+        end
+      else
+        local status_start, status_end = find_token(line, row.status_icon, 1)
+        add_hl(bufnr, ns, lnum, status_hl_group(row.status), status_start, status_end)
 
-      local icon_start, icon_end = find_token(line, row.source_icon, (status_end or 0) + 1)
-      add_hl(bufnr, ns, lnum, 'CosmicUiFmtIcon', icon_start, icon_end)
+        local icon_start, icon_end = find_token(line, row.source_icon, (status_end or 0) + 1)
+        add_hl(bufnr, ns, lnum, 'CosmicUiFmtIcon', icon_start, icon_end)
 
-      if row.reason then
-        local reason_text = ('(%s)'):format(row.reason)
-        local reason_start, reason_end = find_token(line, reason_text, (icon_end or 0) + 1)
-        add_hl(bufnr, ns, lnum, 'CosmicUiFmtUnavailable', reason_start, reason_end)
-      end
-
-      if row.ghost_text then
-        local ghost_start, ghost_end = find_token(line, row.ghost_text, (icon_end or 0) + 1)
-        add_hl(bufnr, ns, lnum, 'CosmicUiFmtHintText', ghost_start, ghost_end)
+        if row.reason then
+          local reason_start, reason_end = find_token(line, row.reason, (icon_end or 0) + 1)
+          add_hl(bufnr, ns, lnum, 'CosmicUiFmtUnavailable', reason_start, reason_end)
+        end
       end
     end
   end
 
-  if ui.footer_lnum then
-    local footer = lines[ui.footer_lnum]
-    highlight_hint_keys(bufnr, ns, ui.footer_lnum - 1, footer)
+  if ui.footer_lnum and ui.footer_spans and lines[ui.footer_lnum] then
+    for _, span in ipairs(ui.footer_spans) do
+      add_hl(bufnr, ns, ui.footer_lnum - 1, span.highlight, span.start_col, span.end_col)
+    end
   end
 end
 

--- a/lua/cosmic-ui/formatters/ui/init.lua
+++ b/lua/cosmic-ui/formatters/ui/init.lua
@@ -73,6 +73,7 @@ M.open = function(opts, handlers)
     win = win,
     selected = nil,
     rows = {},
+    footer = input.footer_entries(),
     cursor_state = window.hide_cursor_with_group('CosmicUiFmtCursor'),
   }
 

--- a/lua/cosmic-ui/formatters/ui/input.lua
+++ b/lua/cosmic-ui/formatters/ui/input.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.footer_entries = function()
   return {
-    'Tab:toggle',
+    'Tab:toggle+next',
     's:scope',
     'r:reset',
     'a:toggle all',

--- a/lua/cosmic-ui/formatters/ui/input.lua
+++ b/lua/cosmic-ui/formatters/ui/input.lua
@@ -1,5 +1,16 @@
 local M = {}
 
+M.footer_entries = function()
+  return {
+    'Tab:toggle',
+    's:scope',
+    'r:reset',
+    'a:toggle all',
+    'f:format',
+    'q:close',
+  }
+end
+
 local function next_toggleable_index(rows, start_idx, step)
   if #rows == 0 then
     return nil

--- a/lua/cosmic-ui/formatters/ui/input.lua
+++ b/lua/cosmic-ui/formatters/ui/input.lua
@@ -91,7 +91,8 @@ local function toggle_all_rows(ui, handlers, deps)
 
   local all_enabled = true
   for _, row in ipairs(toggleable) do
-    local is_enabled = deps.state.get_effective_item_state(row.action.source, row.action.name, ui.scope, ui.target_bufnr)
+    local is_enabled =
+      deps.state.get_effective_item_state(row.action.source, row.action.name, ui.scope, ui.target_bufnr)
     if not is_enabled then
       all_enabled = false
       break

--- a/lua/cosmic-ui/formatters/ui/render.lua
+++ b/lua/cosmic-ui/formatters/ui/render.lua
@@ -1,9 +1,55 @@
+local panel = require('cosmic-ui.ui.panel')
+
 local M = {}
 
 local function clamp_ui_size(width, height)
   local max_width = math.max(50, math.floor(vim.o.columns * 0.9))
   local max_height = math.max(14, math.floor((vim.o.lines - vim.o.cmdheight) * 0.8))
   return math.min(width, max_width), math.min(height, max_height)
+end
+
+local function row_display_text(row)
+  if row.kind == 'section' and row.subtitle and row.subtitle ~= '' then
+    return ('%s  %s'):format(row.text, row.subtitle)
+  end
+
+  return row.text
+end
+
+local function build_footer_line(entries)
+  local text = ''
+  local spans = {}
+  local col = 0
+
+  for idx, entry in ipairs(entries or {}) do
+    if idx > 1 then
+      text = text .. '  '
+      col = col + 2
+    end
+
+    local key = entry.key or ''
+    local hint = entry.text or ''
+
+    text = text .. key
+    table.insert(spans, {
+      highlight = entry.key_highlight,
+      start_col = col,
+      end_col = col + #key,
+    })
+    col = col + #key
+
+    if hint ~= '' then
+      text = text .. ':' .. hint
+      table.insert(spans, {
+        highlight = entry.text_highlight,
+        start_col = col + 1,
+        end_col = col + 1 + #hint,
+      })
+      col = col + 1 + #hint
+    end
+  end
+
+  return text, spans
 end
 
 M.ensure_selection = function(ui)
@@ -61,12 +107,13 @@ M.render = function(ui, handlers, deps)
 
   local icons = deps.rows.make_icons(devicons, ui.target_bufnr)
   local rows = deps.rows.build_rows(status, icons, deps.constants.status_icons)
+  local footer = panel.build({ footer = ui.footer }).footer
 
   ui.rows = rows
   M.ensure_selection(ui)
 
   local header_left = ('%s %s'):format(icons.file, icons.filetype)
-  local header_right = ui.scope
+  local header_right = ('Scope: %s'):format(ui.scope)
   local content_lines = {}
   local header_bottom_padding = 1
   local max_content_width = vim.fn.strdisplaywidth(header_left) + 1 + vim.fn.strdisplaywidth(header_right)
@@ -79,16 +126,24 @@ M.render = function(ui, handlers, deps)
 
   max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(''))
   for _, row in ipairs(rows) do
-    table.insert(content_lines, row.text)
-    max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(row.text))
+    row.rendered_text = row_display_text(row)
+    table.insert(content_lines, row.rendered_text)
+    max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(row.rendered_text))
     row.lnum = #content_lines
   end
 
   table.insert(content_lines, '')
   max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(''))
-  table.insert(content_lines, '<tab>:toggle+next  s:switch scope  r:reset  a:toggle all  f:format  q:close')
-  max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(content_lines[#content_lines]))
-  ui.footer_lnum = #content_lines
+  if #footer > 0 then
+    local footer_text, footer_spans = build_footer_line(footer)
+    table.insert(content_lines, footer_text)
+    max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(footer_text))
+    ui.footer_lnum = #content_lines
+    ui.footer_spans = footer_spans
+  else
+    ui.footer_lnum = nil
+    ui.footer_spans = nil
+  end
 
   local gap = max_content_width - vim.fn.strdisplaywidth(header_left) - vim.fn.strdisplaywidth(header_right)
   if gap < 1 then
@@ -114,12 +169,24 @@ M.render = function(ui, handlers, deps)
     row.lnum = row.lnum + deps.constants.ui_padding.y
   end
   ui.header_lnum = ui.header_lnum + deps.constants.ui_padding.y
-  ui.footer_lnum = ui.footer_lnum + deps.constants.ui_padding.y
+  if ui.footer_lnum then
+    ui.footer_lnum = ui.footer_lnum + deps.constants.ui_padding.y
+  end
+  if ui.footer_spans then
+    for _, span in ipairs(ui.footer_spans) do
+      span.start_col = span.start_col + deps.constants.ui_padding.x
+      span.end_col = span.end_col + deps.constants.ui_padding.x
+    end
+  end
 
   local max_height = math.max(14, math.floor((vim.o.lines - vim.o.cmdheight) * 0.8))
   if #lines > max_height then
     lines = vim.list_slice(lines, 1, max_height)
     lines[#lines] = '...'
+    if ui.footer_lnum and ui.footer_lnum >= #lines then
+      ui.footer_lnum = nil
+      ui.footer_spans = nil
+    end
   end
 
   local width = 0

--- a/lua/cosmic-ui/formatters/ui/render.lua
+++ b/lua/cosmic-ui/formatters/ui/render.lua
@@ -16,42 +16,6 @@ local function row_display_text(row)
   return row.text
 end
 
-local function build_footer_line(entries)
-  local text = ''
-  local spans = {}
-  local col = 0
-
-  for idx, entry in ipairs(entries or {}) do
-    if idx > 1 then
-      text = text .. '  '
-      col = col + 2
-    end
-
-    local key = entry.key or ''
-    local hint = entry.text or ''
-
-    text = text .. key
-    table.insert(spans, {
-      highlight = entry.key_highlight,
-      start_col = col,
-      end_col = col + #key,
-    })
-    col = col + #key
-
-    if hint ~= '' then
-      text = text .. ':' .. hint
-      table.insert(spans, {
-        highlight = entry.text_highlight,
-        start_col = col + 1,
-        end_col = col + 1 + #hint,
-      })
-      col = col + 1 + #hint
-    end
-  end
-
-  return text, spans
-end
-
 M.ensure_selection = function(ui)
   if not ui.rows or #ui.rows == 0 then
     ui.selected = nil
@@ -98,7 +62,7 @@ M.render = function(ui, handlers, deps)
     return
   end
 
-  local ns = deps.highlights.ensure(deps.ui_state, deps.constants.highlight_links)
+  local ns = deps.ui_state.ns
 
   local status = handlers.status_fn({ scope = ui.scope, bufnr = ui.target_bufnr })
   if not status then
@@ -135,7 +99,7 @@ M.render = function(ui, handlers, deps)
   table.insert(content_lines, '')
   max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(''))
   if #footer > 0 then
-    local footer_text, footer_spans = build_footer_line(footer)
+    local footer_text, footer_spans = panel.render_footer(footer)
     table.insert(content_lines, footer_text)
     max_content_width = math.max(max_content_width, vim.fn.strdisplaywidth(footer_text))
     ui.footer_lnum = #content_lines

--- a/lua/cosmic-ui/formatters/ui/rows.lua
+++ b/lua/cosmic-ui/formatters/ui/rows.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+local function push_info_row(rows, row)
+  table.insert(rows, row)
+end
+
 M.get_devicons = function(logger)
   local ok, devicons = pcall(require, 'nvim-web-devicons')
   if not ok then
@@ -48,7 +52,6 @@ M.build_rows = function(status, icons, status_icons)
   local global_mode = fallback.display_global_mode or 'never'
   local specific_mode = fallback.display_specific_mode
   local lsp_header_mode = specific_mode or global_mode
-  local lsp_header_ghost = ('  %s'):format(lsp_header_mode)
 
   table.insert(rows, {
     id = 'section_conform',
@@ -58,19 +61,24 @@ M.build_rows = function(status, icons, status_icons)
   })
 
   if not status.conform.available then
-    table.insert(rows, {
+    push_info_row(rows, {
       id = 'conform_unavailable',
-      text = ('%s %s %s'):format(status_icons.unavailable, icons.conform, status.conform.reason or 'unavailable'),
+      text = ('%s %s Conform unavailable%s'):format(
+        status_icons.unavailable,
+        icons.conform,
+        status.conform.reason and (': ' .. status.conform.reason) or ''
+      ),
       toggleable = false,
       kind = 'info',
       status = 'unavailable',
       status_icon = status_icons.unavailable,
       source_icon = icons.conform,
+      reason = status.conform.reason,
     })
   elseif #status.conform.formatters == 0 then
-    table.insert(rows, {
+    push_info_row(rows, {
       id = 'conform_empty',
-      text = ('%s %s no formatters to run'):format(status_icons.unavailable, icons.conform),
+      text = ('%s %s Conform: no formatters available'):format(status_icons.unavailable, icons.conform),
       toggleable = false,
       kind = 'info',
       status = 'unavailable',
@@ -100,16 +108,16 @@ M.build_rows = function(status, icons, status_icons)
 
   table.insert(rows, {
     id = 'section_lsp',
-    text = 'LSP' .. lsp_header_ghost,
+    text = 'LSP',
+    subtitle = lsp_header_mode,
     toggleable = false,
     kind = 'section',
-    ghost_text = lsp_header_ghost,
   })
 
   if #status.lsp_clients == 0 then
-    table.insert(rows, {
+    push_info_row(rows, {
       id = 'lsp_empty',
-      text = ('%s %s no attached clients'):format(status_icons.unavailable, icons.lsp),
+      text = ('%s %s LSP: no attached clients'):format(status_icons.unavailable, icons.lsp),
       toggleable = false,
       kind = 'info',
       status = 'unavailable',

--- a/lua/cosmic-ui/rename/model.lua
+++ b/lua/cosmic-ui/rename/model.lua
@@ -1,7 +1,15 @@
 local M = {}
 
+function M.extract_value(prompt, raw_line)
+  if vim.startswith(raw_line, prompt) then
+    return raw_line:sub(#prompt + 1)
+  end
+
+  return raw_line
+end
+
 function M.normalize_submission(prompt, raw_line, current_name)
-  local submitted = vim.startswith(raw_line, prompt) and raw_line:sub(#prompt + 1) or raw_line
+  local submitted = M.extract_value(prompt, raw_line)
 
   if submitted == '' then
     return { ok = false, reason = 'empty' }

--- a/lua/cosmic-ui/rename/model.lua
+++ b/lua/cosmic-ui/rename/model.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+function M.normalize_submission(prompt, raw_line, current_name)
+  local submitted = vim.startswith(raw_line, prompt) and raw_line:sub(#prompt + 1) or raw_line
+
+  if submitted == '' then
+    return { ok = false, reason = 'empty' }
+  end
+
+  if submitted == current_name then
+    return { ok = false, reason = 'unchanged' }
+  end
+
+  return { ok = true, value = submitted }
+end
+
+return M

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -130,6 +130,7 @@ local function build_panel_model(curr_name, reason)
   end
 
   return panel.prepare({
+    layout = 'compact',
     rows = rows,
     footer = {
       { key = 'Enter', text = 'rename' },
@@ -148,6 +149,7 @@ local function render(ui, value)
 
   local lines = {}
   local highlights = {}
+  local compact_layout = ui.panel and ui.panel.layout == 'compact'
 
   local function push_line(text, meta)
     table.insert(lines, text)
@@ -156,21 +158,27 @@ local function render(ui, value)
     end
   end
 
-  for _, row in ipairs(ui.panel.rows or {}) do
-    local highlight = row.highlight
-    if row.kind == 'context' then
-      highlight = 'CosmicUiPanelSection'
+  local prompt_line = ui.prompt .. value
+
+  if compact_layout then
+    push_line(prompt_line)
+  else
+    for _, row in ipairs(ui.panel.rows or {}) do
+      local highlight = row.highlight
+      if row.kind == 'context' then
+        highlight = 'CosmicUiPanelSection'
+      end
+
+      push_line(' ' .. (row.text or '') .. ' ', { highlight = highlight })
     end
 
-    push_line(' ' .. (row.text or '') .. ' ', { highlight = highlight })
+    push_line('')
+    push_line(prompt_line)
   end
 
-  push_line('')
-  local prompt_line = ui.prompt .. value
-  push_line(prompt_line)
   local prompt_row = #lines
 
-  if ui.panel.footer and #ui.panel.footer > 0 then
+  if not compact_layout and ui.panel.footer and #ui.panel.footer > 0 then
     push_line('')
     local footer_text, spans = footer_line(ui.panel.footer)
     for _, span in ipairs(spans) do

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -280,6 +280,18 @@ local function backspace(ui)
   set_cursor_col(ui, col - 1)
 end
 
+local function stop_insert_mode_if_needed()
+  local ok, mode = pcall(vim.fn.mode)
+  if not ok or type(mode) ~= 'string' then
+    return
+  end
+
+  local mode_prefix = mode:sub(1, 1)
+  if mode_prefix == 'i' or mode_prefix == 'R' then
+    pcall(vim.cmd, 'stopinsert')
+  end
+end
+
 M.open = function(opts)
   validate_open_opts(opts)
 
@@ -377,6 +389,7 @@ M.open = function(opts)
     value = default_value,
     validation_reason = nil,
     origin_win = target_winid,
+    origin_cursor = target_cursor,
     fixed_width = opts.window and opts.window.width or nil,
     fixed_height = opts.window and opts.window.height or nil,
     closed = false,
@@ -386,15 +399,40 @@ M.open = function(opts)
   local augroup = vim.api.nvim_create_augroup('cosmic_ui_rename_' .. tostring(buf), { clear = true })
   ui.augroup = augroup
 
-  local function close()
+  local function restore_origin_state()
+    window.restore_focus(ui.origin_win)
+    if ui.origin_win and ui.origin_cursor and vim.api.nvim_win_is_valid(ui.origin_win) then
+      pcall(vim.api.nvim_win_set_cursor, ui.origin_win, ui.origin_cursor)
+    end
+  end
+
+  local function restore_origin_state_deferred()
+    vim.schedule(function()
+      vim.schedule(restore_origin_state)
+    end)
+  end
+
+  local function close(opts)
+    opts = opts or {}
+
     if ui.closed then
       return
     end
     ui.closed = true
 
+    stop_insert_mode_if_needed()
     pcall(vim.api.nvim_del_augroup_by_id, augroup)
     window.safe_close_win(win)
     window.safe_delete_buf(buf, { force = true })
+    if opts.restore_origin_state then
+      restore_origin_state_deferred()
+    end
+  end
+
+  local function cancel()
+    close({
+      restore_origin_state = true,
+    })
   end
 
   local function submit()
@@ -421,13 +459,13 @@ M.open = function(opts)
   vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
     group = augroup,
     buffer = buf,
-    callback = close,
+    callback = cancel,
   })
 
   vim.api.nvim_create_autocmd('WinClosed', {
     group = augroup,
     pattern = tostring(win),
-    callback = close,
+    callback = cancel,
   })
 
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
@@ -446,8 +484,8 @@ M.open = function(opts)
     set_cursor_col(ui, ui.prompt_col)
   end, map_opts)
   vim.keymap.set({ 'i', 'n' }, '<CR>', submit, map_opts)
-  vim.keymap.set({ 'i', 'n' }, '<Esc>', close, map_opts)
-  vim.keymap.set({ 'i', 'n' }, '<C-c>', close, map_opts)
+  vim.keymap.set({ 'i', 'n' }, '<Esc>', cancel, map_opts)
+  vim.keymap.set({ 'i', 'n' }, '<C-c>', cancel, map_opts)
 
   render(ui, default_value)
   vim.api.nvim_set_current_win(win)

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -194,8 +194,10 @@ local function render(ui, value)
     vim.api.nvim_win_set_config(ui.win, cfg)
   end
 
+  local was_modifiable = vim.bo[ui.buf].modifiable
   vim.bo[ui.buf].modifiable = true
   vim.api.nvim_buf_set_lines(ui.buf, 0, -1, false, lines)
+  vim.bo[ui.buf].modifiable = was_modifiable
 
   vim.api.nvim_buf_clear_namespace(ui.buf, panel_ns, 0, -1)
   vim.api.nvim_buf_clear_namespace(ui.buf, prompt_ns, 0, -1)
@@ -270,6 +272,14 @@ local function backspace(ui)
   set_cursor_col(ui, col - 1)
 end
 
+local function set_editable(ui, editable)
+  if not (ui and ui.buf and vim.api.nvim_buf_is_valid(ui.buf)) then
+    return
+  end
+
+  vim.bo[ui.buf].modifiable = editable
+end
+
 M.open = function(opts)
   validate_open_opts(opts)
 
@@ -314,7 +324,7 @@ M.open = function(opts)
 
   local buf = window.create_scratch_buf({
     filetype = 'cosmicui-rename',
-    modifiable = true,
+    modifiable = false,
     bufhidden = 'wipe',
   })
   if not buf then
@@ -425,6 +435,23 @@ M.open = function(opts)
     buffer = buf,
     callback = function()
       ensure_cursor_after_prompt(ui)
+    end,
+  })
+
+  vim.api.nvim_create_autocmd('InsertEnter', {
+    group = augroup,
+    buffer = buf,
+    callback = function()
+      set_editable(ui, true)
+      ensure_cursor_after_prompt(ui)
+    end,
+  })
+
+  vim.api.nvim_create_autocmd('InsertLeave', {
+    group = augroup,
+    buffer = buf,
+    callback = function()
+      set_editable(ui, false)
     end,
   })
 

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -134,7 +134,7 @@ local function build_panel_model(curr_name, reason)
     rows = rows,
     footer = {
       { key = 'Enter', text = 'rename' },
-      { key = 'Esc', text = 'cancel' },
+      { key = 'Esc',   text = 'cancel' },
     },
   })
 end
@@ -312,11 +312,11 @@ M.open = function(opts)
   local prompt = opts.prompt or user_opts.prompt or '> '
   local default_value = opts.default_value or curr_name
   local on_submit = opts.on_submit
-    or default_submitter(curr_name, {
-      bufnr = target_bufnr,
-      winid = target_winid,
-      cursor = target_cursor,
-    })
+      or default_submitter(curr_name, {
+        bufnr = target_bufnr,
+        winid = target_winid,
+        cursor = target_cursor,
+      })
 
   local merged_window_opts = utils.merge({
     relative = 'cursor',

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -2,17 +2,10 @@ local lsp = vim.lsp
 local utils = require('cosmic-ui.utils')
 local config = require('cosmic-ui.config')
 local window = require('cosmic-ui.window')
-local panel = require('cosmic-ui.ui.panel')
 local model = require('cosmic-ui.rename.model')
 
 local M = {}
 local prompt_ns = vim.api.nvim_create_namespace('cosmic-ui-rename-prompt')
-local panel_ns = vim.api.nvim_create_namespace('cosmic-ui-rename-panel')
-
-local validation_copy = {
-  empty = 'Name cannot be empty',
-  unchanged = 'Name is unchanged',
-}
 
 local function assert_table(val)
   return val == nil or type(val) == 'table'
@@ -70,129 +63,19 @@ local function default_submitter(curr_name, target_ctx)
   end
 end
 
-local function footer_line(entries)
-  local text = ''
-  local spans = {}
-  local col = 0
-
-  for idx, entry in ipairs(entries or {}) do
-    if idx > 1 then
-      text = text .. '  '
-      col = col + 2
-    end
-
-    local key = entry.key or ''
-    local hint = entry.text or ''
-
-    text = text .. key
-    table.insert(spans, {
-      highlight = entry.key_highlight,
-      start_col = col,
-      end_col = col + #key,
-    })
-    col = col + #key
-
-    if hint ~= '' then
-      text = text .. ':' .. hint
-      table.insert(spans, {
-        highlight = entry.text_highlight,
-        start_col = col + 1,
-        end_col = col + 1 + #hint,
-      })
-      col = col + 1 + #hint
-    end
-  end
-
-  return text, spans
-end
-
-local function build_validation_row(reason)
-  local text = validation_copy[reason]
-  if not text then
-    return nil
-  end
-
-  return {
-    kind = 'state',
-    state = (reason == 'unchanged') and 'warn' or 'error',
-    text = text,
-  }
-end
-
-local function build_panel_model(curr_name, reason)
-  local rows = {
-    { kind = 'context', text = ('Current: %s'):format(curr_name) },
-  }
-
-  local validation_row = build_validation_row(reason)
-  if validation_row then
-    table.insert(rows, validation_row)
-  end
-
-  return panel.prepare({
-    layout = 'compact',
-    rows = rows,
-    footer = {
-      { key = 'Enter', text = 'rename' },
-      { key = 'Esc', text = 'cancel' },
-    },
-  })
-end
-
 local function render(ui, value)
   if not (ui.buf and vim.api.nvim_buf_is_valid(ui.buf)) then
     return
   end
 
   ui.value = value
-  ui.panel = build_panel_model(ui.curr_name, ui.validation_reason)
-
-  local lines = {}
-  local highlights = {}
-  local compact_layout = ui.panel and ui.panel.layout == 'compact'
-
-  local function push_line(text, meta)
-    table.insert(lines, text)
-    if meta then
-      highlights[#lines] = meta
-    end
-  end
-
   local prompt_line = ui.prompt .. value
-
-  if compact_layout then
-    push_line(prompt_line)
-  else
-    for _, row in ipairs(ui.panel.rows or {}) do
-      local highlight = row.highlight
-      if row.kind == 'context' then
-        highlight = 'CosmicUiPanelSection'
-      end
-
-      push_line(' ' .. (row.text or '') .. ' ', { highlight = highlight })
-    end
-
-    push_line('')
-    push_line(prompt_line)
-  end
-
-  local prompt_row = #lines
-
-  if not compact_layout and ui.panel.footer and #ui.panel.footer > 0 then
-    push_line('')
-    local footer_text, spans = footer_line(ui.panel.footer)
-    for _, span in ipairs(spans) do
-      span.start_col = span.start_col + 1
-      span.end_col = span.end_col + 1
-    end
-    push_line(' ' .. footer_text .. ' ', { spans = spans })
-  end
+  local lines = { prompt_line }
+  local prompt_row = 1
 
   local width = ui.fixed_width or 30
   if not ui.fixed_width then
-    for _, line in ipairs(lines) do
-      width = math.max(width, vim.fn.strdisplaywidth(line))
-    end
+    width = math.max(width, vim.fn.strdisplaywidth(prompt_line))
   end
 
   if ui.win and vim.api.nvim_win_is_valid(ui.win) then
@@ -207,20 +90,7 @@ local function render(ui, value)
   vim.api.nvim_buf_set_lines(ui.buf, 0, -1, false, lines)
   vim.bo[ui.buf].modifiable = was_modifiable
 
-  vim.api.nvim_buf_clear_namespace(ui.buf, panel_ns, 0, -1)
   vim.api.nvim_buf_clear_namespace(ui.buf, prompt_ns, 0, -1)
-
-  for line_no, meta in pairs(highlights) do
-    if meta.highlight then
-      vim.api.nvim_buf_add_highlight(ui.buf, panel_ns, meta.highlight, line_no - 1, 0, -1)
-    end
-
-    for _, span in ipairs(meta.spans or {}) do
-      if span.end_col >= span.start_col then
-        vim.api.nvim_buf_add_highlight(ui.buf, panel_ns, span.highlight, line_no - 1, span.start_col, span.end_col)
-      end
-    end
-  end
 
   if #ui.prompt > 0 then
     vim.api.nvim_buf_set_extmark(ui.buf, prompt_ns, prompt_row - 1, 0, {
@@ -385,9 +255,7 @@ M.open = function(opts)
     win = win,
     prompt = prompt,
     prompt_hl = user_opts.prompt_hl or 'Comment',
-    curr_name = curr_name,
     value = default_value,
-    validation_reason = nil,
     origin_win = target_winid,
     origin_cursor = target_cursor,
     fixed_width = opts.window and opts.window.width or nil,
@@ -444,9 +312,7 @@ M.open = function(opts)
     local result = model.normalize_submission(prompt, raw_line, curr_name)
 
     if not result.ok then
-      ui.validation_reason = result.reason
       ui.value = model.extract_value(prompt, raw_line)
-      ui.panel = build_panel_model(ui.curr_name, ui.validation_reason)
       return
     end
 

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -2,9 +2,17 @@ local lsp = vim.lsp
 local utils = require('cosmic-ui.utils')
 local config = require('cosmic-ui.config')
 local window = require('cosmic-ui.window')
+local panel = require('cosmic-ui.ui.panel')
+local model = require('cosmic-ui.rename.model')
 
 local M = {}
 local prompt_ns = vim.api.nvim_create_namespace('cosmic-ui-rename-prompt')
+local panel_ns = vim.api.nvim_create_namespace('cosmic-ui-rename-panel')
+
+local validation_copy = {
+  empty = 'Name cannot be empty',
+  unchanged = 'Name is unchanged',
+}
 
 local function assert_table(val)
   return val == nil or type(val) == 'table'
@@ -51,10 +59,6 @@ end
 
 local function default_submitter(curr_name, target_ctx)
   return function(new_name)
-    if not (new_name and #new_name > 0) or new_name == curr_name then
-      return
-    end
-
     if not (target_ctx.winid and vim.api.nvim_win_is_valid(target_ctx.winid)) then
       return
     end
@@ -64,6 +68,208 @@ local function default_submitter(curr_name, target_ctx)
       lsp.buf.rename(new_name, { bufnr = target_ctx.bufnr })
     end)
   end
+end
+
+local function extract_value(prompt, raw_line)
+  if vim.startswith(raw_line, prompt) then
+    return raw_line:sub(#prompt + 1)
+  end
+
+  return raw_line
+end
+
+local function footer_line(entries)
+  local text = ''
+  local spans = {}
+
+  for idx, entry in ipairs(entries or {}) do
+    if idx > 1 then
+      text = text .. '  '
+    end
+
+    local key_start = #text + 1
+    text = text .. entry.key
+    local key_end = #text
+    table.insert(spans, {
+      highlight = entry.key_highlight,
+      start_col = key_start,
+      end_col = key_end,
+    })
+
+    if entry.text ~= '' then
+      text = text .. ':' .. entry.text
+      table.insert(spans, {
+        highlight = entry.text_highlight,
+        start_col = key_end + 2,
+        end_col = #text,
+      })
+    end
+  end
+
+  return text, spans
+end
+
+local function build_validation_row(reason)
+  local text = validation_copy[reason]
+  if not text then
+    return nil
+  end
+
+  return {
+    kind = 'state',
+    state = (reason == 'unchanged') and 'warn' or 'error',
+    text = text,
+  }
+end
+
+local function build_panel_model(curr_name, reason)
+  local rows = {
+    { kind = 'context', text = ('Current: %s'):format(curr_name) },
+  }
+
+  local validation_row = build_validation_row(reason)
+  if validation_row then
+    table.insert(rows, validation_row)
+  end
+
+  return panel.prepare({
+    rows = rows,
+    footer = {
+      { key = 'Enter', text = 'rename' },
+      { key = 'Esc', text = 'cancel' },
+    },
+  })
+end
+
+local function render(ui, value)
+  if not (ui.buf and vim.api.nvim_buf_is_valid(ui.buf)) then
+    return
+  end
+
+  ui.value = value
+  ui.panel = build_panel_model(ui.curr_name, ui.validation_reason)
+
+  local lines = {}
+  local highlights = {}
+
+  local function push_line(text, meta)
+    table.insert(lines, text)
+    if meta then
+      highlights[#lines] = meta
+    end
+  end
+
+  for _, row in ipairs(ui.panel.rows or {}) do
+    local highlight = row.highlight
+    if row.kind == 'context' then
+      highlight = 'CosmicUiPanelSection'
+    end
+
+    push_line(' ' .. (row.text or '') .. ' ', { highlight = highlight })
+  end
+
+  push_line('')
+  local prompt_line = ui.prompt .. value
+  push_line(prompt_line)
+  local prompt_row = #lines
+
+  if ui.panel.footer and #ui.panel.footer > 0 then
+    push_line('')
+    local footer_text, spans = footer_line(ui.panel.footer)
+    for _, span in ipairs(spans) do
+      span.start_col = span.start_col + 1
+      span.end_col = span.end_col + 1
+    end
+    push_line(' ' .. footer_text .. ' ', { spans = spans })
+  end
+
+  local width = 30
+  for _, line in ipairs(lines) do
+    width = math.max(width, vim.fn.strdisplaywidth(line))
+  end
+
+  if ui.win and vim.api.nvim_win_is_valid(ui.win) then
+    local cfg = vim.api.nvim_win_get_config(ui.win)
+    cfg.width = width
+    cfg.height = #lines
+    vim.api.nvim_win_set_config(ui.win, cfg)
+  end
+
+  vim.bo[ui.buf].modifiable = true
+  vim.api.nvim_buf_set_lines(ui.buf, 0, -1, false, lines)
+  vim.bo[ui.buf].modifiable = false
+
+  vim.api.nvim_buf_clear_namespace(ui.buf, panel_ns, 0, -1)
+  vim.api.nvim_buf_clear_namespace(ui.buf, prompt_ns, 0, -1)
+
+  for line_no, meta in pairs(highlights) do
+    if meta.highlight then
+      vim.api.nvim_buf_add_highlight(ui.buf, panel_ns, meta.highlight, line_no - 1, 0, -1)
+    end
+
+    for _, span in ipairs(meta.spans or {}) do
+      if span.end_col >= span.start_col then
+        vim.api.nvim_buf_add_highlight(ui.buf, panel_ns, span.highlight, line_no - 1, span.start_col, span.end_col)
+      end
+    end
+  end
+
+  if #ui.prompt > 0 then
+    vim.api.nvim_buf_set_extmark(ui.buf, prompt_ns, prompt_row - 1, 0, {
+      end_row = prompt_row - 1,
+      end_col = #ui.prompt,
+      hl_group = ui.prompt_hl,
+      priority = 300,
+    })
+  end
+
+  ui.prompt_row = prompt_row
+  ui.prompt_col = #ui.prompt
+
+  if ui.win and vim.api.nvim_win_is_valid(ui.win) then
+    pcall(vim.api.nvim_win_set_cursor, ui.win, { prompt_row, #prompt_line })
+  end
+end
+
+local function set_cursor_col(ui, col)
+  return pcall(vim.api.nvim_win_set_cursor, ui.win, { ui.prompt_row, col })
+end
+
+local function ensure_cursor_after_prompt(ui)
+  if not (ui.win and vim.api.nvim_win_is_valid(ui.win)) then
+    return
+  end
+
+  local cursor = vim.api.nvim_win_get_cursor(ui.win)
+  local prompt_line = vim.api.nvim_buf_get_lines(ui.buf, ui.prompt_row - 1, ui.prompt_row, true)[1] or ''
+  local col = cursor[2]
+
+  if cursor[1] ~= ui.prompt_row then
+    set_cursor_col(ui, math.max(ui.prompt_col, math.min(col, #prompt_line)))
+    return
+  end
+
+  if col < ui.prompt_col then
+    set_cursor_col(ui, ui.prompt_col)
+  elseif col > #prompt_line then
+    set_cursor_col(ui, #prompt_line)
+  end
+end
+
+local function backspace(ui)
+  local cursor = vim.api.nvim_win_get_cursor(ui.win)
+  local col = cursor[2]
+  if cursor[1] ~= ui.prompt_row then
+    ensure_cursor_after_prompt(ui)
+    return
+  end
+
+  if col <= ui.prompt_col then
+    return
+  end
+
+  vim.api.nvim_buf_set_text(ui.buf, ui.prompt_row - 1, col - 1, ui.prompt_row - 1, col, { '' })
+  set_cursor_col(ui, col - 1)
 end
 
 M.open = function(opts)
@@ -83,7 +289,6 @@ M.open = function(opts)
 
   local user_opts = config.module_opts('rename') or {}
   local user_border = user_opts.border or {}
-
   local prompt = opts.prompt or user_opts.prompt or '> '
   local default_value = opts.default_value or curr_name
   local on_submit = opts.on_submit
@@ -93,13 +298,12 @@ M.open = function(opts)
       cursor = target_cursor,
     })
 
-  local width = math.max(25, #default_value + #prompt + 1)
   local merged_window_opts = utils.merge({
     relative = 'cursor',
     row = 1,
     col = 0,
-    width = width,
-    height = 1,
+    width = math.max(30, #prompt + #default_value + 2),
+    height = 5,
     zindex = 50,
     border = {
       style = user_border.style or vim.o.winborder,
@@ -128,8 +332,8 @@ M.open = function(opts)
     relative = merged_window_opts.relative,
     row = merged_window_opts.row,
     col = merged_window_opts.col,
-    width = math.max(1, merged_window_opts.width or width),
-    height = math.max(1, merged_window_opts.height or 1),
+    width = math.max(1, merged_window_opts.width or 30),
+    height = math.max(1, merged_window_opts.height or 5),
     zindex = merged_window_opts.zindex,
     border = border.style,
     title = border.title,
@@ -139,6 +343,11 @@ M.open = function(opts)
     window.safe_delete_buf(buf, { force = true })
     return
   end
+
+  vim.wo[win].number = false
+  vim.wo[win].relativenumber = false
+  vim.wo[win].signcolumn = 'no'
+  vim.wo[win].wrap = false
 
   local winhl = {}
   if border.highlight then
@@ -151,80 +360,52 @@ M.open = function(opts)
     vim.wo[win].winhl = table.concat(winhl, ',')
   end
 
-  local line = prompt .. default_value
-  local prompt_len = #prompt
-  local prompt_hl = user_opts.prompt_hl or 'Comment'
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, { line })
-  vim.api.nvim_buf_clear_namespace(buf, prompt_ns, 0, -1)
-  if prompt_len > 0 then
-    vim.api.nvim_buf_set_extmark(buf, prompt_ns, 0, 0, {
-      end_row = 0,
-      end_col = prompt_len,
-      hl_group = prompt_hl,
-      priority = 300,
-    })
-  end
+  local ui = {
+    buf = buf,
+    win = win,
+    prompt = prompt,
+    prompt_hl = user_opts.prompt_hl or 'Comment',
+    curr_name = curr_name,
+    value = default_value,
+    validation_reason = nil,
+    origin_win = target_winid,
+    closed = false,
+    submitted = false,
+  }
 
-  local closed = false
-  local submitted = false
   local augroup = vim.api.nvim_create_augroup('cosmic_ui_rename_' .. tostring(buf), { clear = true })
+  ui.augroup = augroup
 
   local function close()
-    if closed then
+    if ui.closed then
       return
     end
-    closed = true
+    ui.closed = true
 
     pcall(vim.api.nvim_del_augroup_by_id, augroup)
     window.safe_close_win(win)
     window.safe_delete_buf(buf, { force = true })
+    panel.restore_focus(ui.origin_win)
   end
 
-  local function submit(new_name_arg)
-    if submitted then
+  local function submit()
+    local raw_line = vim.api.nvim_buf_get_lines(buf, ui.prompt_row - 1, ui.prompt_row, true)[1] or ''
+    local result = model.normalize_submission(prompt, raw_line, curr_name)
+
+    if not result.ok then
+      ui.validation_reason = result.reason
+      render(ui, extract_value(prompt, raw_line))
       return
     end
-    submitted = true
 
-    local new_name = new_name_arg or vim.api.nvim_get_current_line()
-    if vim.startswith(new_name, prompt) then
-      new_name = new_name:sub(#prompt + 1)
+    if ui.submitted then
+      return
     end
+    ui.submitted = true
     close()
     vim.schedule(function()
-      on_submit(new_name)
+      on_submit(result.value)
     end)
-  end
-
-  local function set_cursor_col(col)
-    local ok = pcall(vim.api.nvim_win_set_cursor, win, { 1, col })
-    return ok
-  end
-
-  local function ensure_cursor_after_prompt()
-    if not (win and vim.api.nvim_win_is_valid(win)) then
-      return
-    end
-    local cursor = vim.api.nvim_win_get_cursor(win)
-    local col = cursor[2]
-    local current_line = vim.api.nvim_buf_get_lines(buf, 0, 1, true)[1] or ''
-    local min_col = prompt_len
-    local max_col = #current_line
-    if col < min_col then
-      set_cursor_col(min_col)
-    elseif col > max_col then
-      set_cursor_col(max_col)
-    end
-  end
-
-  local function backspace()
-    local cursor = vim.api.nvim_win_get_cursor(win)
-    local col = cursor[2]
-    if col <= prompt_len then
-      return
-    end
-    vim.api.nvim_buf_set_text(buf, 0, col - 1, 0, col, { '' })
-    set_cursor_col(col - 1)
   end
 
   vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
@@ -242,20 +423,25 @@ M.open = function(opts)
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
     group = augroup,
     buffer = buf,
-    callback = ensure_cursor_after_prompt,
+    callback = function()
+      ensure_cursor_after_prompt(ui)
+    end,
   })
 
   local map_opts = { buffer = buf, silent = true, nowait = true }
-  vim.keymap.set('i', '<BS>', backspace, map_opts)
+  vim.keymap.set('i', '<BS>', function()
+    backspace(ui)
+  end, map_opts)
   vim.keymap.set({ 'i', 'n' }, '<Home>', function()
-    set_cursor_col(prompt_len)
+    set_cursor_col(ui, ui.prompt_col)
   end, map_opts)
   vim.keymap.set({ 'i', 'n' }, '<CR>', submit, map_opts)
   vim.keymap.set({ 'i', 'n' }, '<Esc>', close, map_opts)
   vim.keymap.set({ 'i', 'n' }, '<C-c>', close, map_opts)
 
+  render(ui, default_value)
   vim.api.nvim_set_current_win(win)
-  vim.api.nvim_win_set_cursor(win, { 1, #line })
+  vim.api.nvim_win_set_cursor(win, { ui.prompt_row, #prompt + #default_value })
   vim.cmd('startinsert!')
 end
 

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -70,14 +70,6 @@ local function default_submitter(curr_name, target_ctx)
   end
 end
 
-local function extract_value(prompt, raw_line)
-  if vim.startswith(raw_line, prompt) then
-    return raw_line:sub(#prompt + 1)
-  end
-
-  return raw_line
-end
-
 local function footer_line(entries)
   local text = ''
   local spans = {}
@@ -183,21 +175,22 @@ local function render(ui, value)
     push_line(' ' .. footer_text .. ' ', { spans = spans })
   end
 
-  local width = 30
-  for _, line in ipairs(lines) do
-    width = math.max(width, vim.fn.strdisplaywidth(line))
+  local width = ui.fixed_width or 30
+  if not ui.fixed_width then
+    for _, line in ipairs(lines) do
+      width = math.max(width, vim.fn.strdisplaywidth(line))
+    end
   end
 
   if ui.win and vim.api.nvim_win_is_valid(ui.win) then
     local cfg = vim.api.nvim_win_get_config(ui.win)
     cfg.width = width
-    cfg.height = #lines
+    cfg.height = ui.fixed_height or #lines
     vim.api.nvim_win_set_config(ui.win, cfg)
   end
 
   vim.bo[ui.buf].modifiable = true
   vim.api.nvim_buf_set_lines(ui.buf, 0, -1, false, lines)
-  vim.bo[ui.buf].modifiable = false
 
   vim.api.nvim_buf_clear_namespace(ui.buf, panel_ns, 0, -1)
   vim.api.nvim_buf_clear_namespace(ui.buf, prompt_ns, 0, -1)
@@ -369,6 +362,8 @@ M.open = function(opts)
     value = default_value,
     validation_reason = nil,
     origin_win = target_winid,
+    fixed_width = opts.window and opts.window.width or nil,
+    fixed_height = opts.window and opts.window.height or nil,
     closed = false,
     submitted = false,
   }
@@ -394,7 +389,7 @@ M.open = function(opts)
 
     if not result.ok then
       ui.validation_reason = result.reason
-      render(ui, extract_value(prompt, raw_line))
+      render(ui, model.extract_value(prompt, raw_line))
       return
     end
 

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -134,7 +134,7 @@ local function build_panel_model(curr_name, reason)
     rows = rows,
     footer = {
       { key = 'Enter', text = 'rename' },
-      { key = 'Esc',   text = 'cancel' },
+      { key = 'Esc', text = 'cancel' },
     },
   })
 end
@@ -312,11 +312,11 @@ M.open = function(opts)
   local prompt = opts.prompt or user_opts.prompt or '> '
   local default_value = opts.default_value or curr_name
   local on_submit = opts.on_submit
-      or default_submitter(curr_name, {
-        bufnr = target_bufnr,
-        winid = target_winid,
-        cursor = target_cursor,
-      })
+    or default_submitter(curr_name, {
+      bufnr = target_bufnr,
+      winid = target_winid,
+      cursor = target_cursor,
+    })
 
   local merged_window_opts = utils.merge({
     relative = 'cursor',
@@ -435,6 +435,10 @@ M.open = function(opts)
     })
   end
 
+  local function dismiss()
+    close()
+  end
+
   local function submit()
     local raw_line = vim.api.nvim_buf_get_lines(buf, ui.prompt_row - 1, ui.prompt_row, true)[1] or ''
     local result = model.normalize_submission(prompt, raw_line, curr_name)
@@ -459,13 +463,13 @@ M.open = function(opts)
   vim.api.nvim_create_autocmd({ 'BufLeave', 'WinLeave' }, {
     group = augroup,
     buffer = buf,
-    callback = cancel,
+    callback = dismiss,
   })
 
   vim.api.nvim_create_autocmd('WinClosed', {
     group = augroup,
     pattern = tostring(win),
-    callback = cancel,
+    callback = dismiss,
   })
 
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -73,28 +73,33 @@ end
 local function footer_line(entries)
   local text = ''
   local spans = {}
+  local col = 0
 
   for idx, entry in ipairs(entries or {}) do
     if idx > 1 then
       text = text .. '  '
+      col = col + 2
     end
 
-    local key_start = #text + 1
-    text = text .. entry.key
-    local key_end = #text
+    local key = entry.key or ''
+    local hint = entry.text or ''
+
+    text = text .. key
     table.insert(spans, {
       highlight = entry.key_highlight,
-      start_col = key_start,
-      end_col = key_end,
+      start_col = col,
+      end_col = col + #key,
     })
+    col = col + #key
 
-    if entry.text ~= '' then
-      text = text .. ':' .. entry.text
+    if hint ~= '' then
+      text = text .. ':' .. hint
       table.insert(spans, {
         highlight = entry.text_highlight,
-        start_col = key_end + 2,
-        end_col = #text,
+        start_col = col + 1,
+        end_col = col + 1 + #hint,
       })
+      col = col + 1 + #hint
     end
   end
 

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -403,7 +403,6 @@ M.open = function(opts)
     pcall(vim.api.nvim_del_augroup_by_id, augroup)
     window.safe_close_win(win)
     window.safe_delete_buf(buf, { force = true })
-    panel.restore_focus(ui.origin_win)
   end
 
   local function submit()
@@ -412,7 +411,8 @@ M.open = function(opts)
 
     if not result.ok then
       ui.validation_reason = result.reason
-      render(ui, model.extract_value(prompt, raw_line))
+      ui.value = model.extract_value(prompt, raw_line)
+      ui.panel = build_panel_model(ui.curr_name, ui.validation_reason)
       return
     end
 

--- a/lua/cosmic-ui/rename/ui.lua
+++ b/lua/cosmic-ui/rename/ui.lua
@@ -280,14 +280,6 @@ local function backspace(ui)
   set_cursor_col(ui, col - 1)
 end
 
-local function set_editable(ui, editable)
-  if not (ui and ui.buf and vim.api.nvim_buf_is_valid(ui.buf)) then
-    return
-  end
-
-  vim.bo[ui.buf].modifiable = editable
-end
-
 M.open = function(opts)
   validate_open_opts(opts)
 
@@ -332,7 +324,7 @@ M.open = function(opts)
 
   local buf = window.create_scratch_buf({
     filetype = 'cosmicui-rename',
-    modifiable = false,
+    modifiable = true,
     bufhidden = 'wipe',
   })
   if not buf then
@@ -443,23 +435,6 @@ M.open = function(opts)
     buffer = buf,
     callback = function()
       ensure_cursor_after_prompt(ui)
-    end,
-  })
-
-  vim.api.nvim_create_autocmd('InsertEnter', {
-    group = augroup,
-    buffer = buf,
-    callback = function()
-      set_editable(ui, true)
-      ensure_cursor_after_prompt(ui)
-    end,
-  })
-
-  vim.api.nvim_create_autocmd('InsertLeave', {
-    group = augroup,
-    buffer = buf,
-    callback = function()
-      set_editable(ui, false)
     end,
   })
 

--- a/lua/cosmic-ui/ui/constants.lua
+++ b/lua/cosmic-ui/ui/constants.lua
@@ -13,7 +13,7 @@ return {
     CosmicUiPanelSubtitle = 'Comment',
     CosmicUiPanelSection = 'Type',
     CosmicUiPanelHintKey = 'Special',
-    CosmicUiPanelHintText = 'Comment',
+    CosmicUiPanelHintText = 'NormalFloat',
     CosmicUiPanelStateInfo = 'Comment',
     CosmicUiPanelStateWarn = 'WarningMsg',
     CosmicUiPanelStateError = 'ErrorMsg',

--- a/lua/cosmic-ui/ui/constants.lua
+++ b/lua/cosmic-ui/ui/constants.lua
@@ -1,0 +1,14 @@
+return {
+  padding = { x = 1, y = 0 },
+  hints = { submit = 'Enter', close = 'Esc' },
+  highlight_links = {
+    CosmicUiPanelTitle = 'Title',
+    CosmicUiPanelSubtitle = 'Comment',
+    CosmicUiPanelSection = 'Type',
+    CosmicUiPanelHintKey = 'Special',
+    CosmicUiPanelHintText = 'Comment',
+    CosmicUiPanelStateInfo = 'Comment',
+    CosmicUiPanelStateWarn = 'WarningMsg',
+    CosmicUiPanelStateError = 'ErrorMsg',
+  },
+}

--- a/lua/cosmic-ui/ui/constants.lua
+++ b/lua/cosmic-ui/ui/constants.lua
@@ -1,6 +1,13 @@
 return {
   padding = { x = 1, y = 0 },
   hints = { submit = 'Enter', close = 'Esc' },
+  state_highlights = {
+    empty = 'CosmicUiPanelStateInfo',
+    info = 'CosmicUiPanelStateInfo',
+    warn = 'CosmicUiPanelStateWarn',
+    warning = 'CosmicUiPanelStateWarn',
+    error = 'CosmicUiPanelStateError',
+  },
   highlight_links = {
     CosmicUiPanelTitle = 'Title',
     CosmicUiPanelSubtitle = 'Comment',

--- a/lua/cosmic-ui/ui/highlights.lua
+++ b/lua/cosmic-ui/ui/highlights.lua
@@ -1,0 +1,11 @@
+local constants = require('cosmic-ui.ui.constants')
+
+local M = {}
+
+function M.ensure()
+  for name, link in pairs(constants.highlight_links) do
+    vim.api.nvim_set_hl(0, name, { link = link, default = true })
+  end
+end
+
+return M

--- a/lua/cosmic-ui/ui/highlights.lua
+++ b/lua/cosmic-ui/ui/highlights.lua
@@ -2,6 +2,10 @@ local constants = require('cosmic-ui.ui.constants')
 
 local M = {}
 
+function M.group_for_state(state)
+  return constants.state_highlights[state] or constants.state_highlights.info
+end
+
 function M.ensure()
   for name, link in pairs(constants.highlight_links) do
     vim.api.nvim_set_hl(0, name, { link = link, default = true })

--- a/lua/cosmic-ui/ui/panel.lua
+++ b/lua/cosmic-ui/ui/panel.lua
@@ -42,6 +42,59 @@ local function normalize_footer(entries)
   return footer
 end
 
+function M.render_footer(entries)
+  local text = ''
+  local spans = {}
+  local col = 0
+
+  for idx, entry in ipairs(entries or {}) do
+    if idx > 1 then
+      text = text .. '  '
+      col = col + 2
+    end
+
+    local key = entry.key or ''
+    local hint = entry.text or ''
+
+    text = text .. key
+    table.insert(spans, {
+      highlight = entry.key_highlight,
+      start_col = col,
+      end_col = col + #key,
+    })
+    col = col + #key
+
+    if hint ~= '' then
+      text = text .. ':' .. hint
+      table.insert(spans, {
+        highlight = entry.text_highlight,
+        start_col = col + 1,
+        end_col = col + 1 + #hint,
+      })
+      col = col + 1 + #hint
+    end
+  end
+
+  return text, spans
+end
+
+local function finalize_standard_text(spec, width)
+  local text = spec.text or ''
+  if not spec.center then
+    return text
+  end
+
+  local text_width = vim.fn.strdisplaywidth(text)
+  if text_width >= width then
+    return text
+  end
+
+  local total_padding = width - text_width
+  local left_padding = math.floor(total_padding / 2)
+  local right_padding = total_padding - left_padding
+  return string.rep(' ', left_padding) .. text .. string.rep(' ', right_padding)
+end
+
 local function normalize_row(row)
   local normalized = vim.tbl_extend('force', {}, row or {})
 
@@ -104,6 +157,90 @@ end
 function M.prepare(opts)
   highlights.ensure()
   return M.build(opts)
+end
+
+function M.prepare_standard(model, opts)
+  model = model or {}
+  opts = opts or {}
+
+  local line_specs = {}
+  local action_line_by_idx = {}
+  local raw_max_width = 30
+  local action_idx = 0
+  local seen_section = false
+
+  local function push_line(spec)
+    spec = spec or { text = '' }
+    table.insert(line_specs, spec)
+    raw_max_width = math.max(raw_max_width, vim.fn.strdisplaywidth(spec.text or ''))
+  end
+
+  for _, row in ipairs(model.rows or {}) do
+    if row.kind == 'section' or row.kind == 'separator' then
+      if seen_section then
+        push_line({ text = '' })
+      end
+      push_line({
+        text = row.text or '',
+        center = true,
+        meta = { highlight = 'CosmicUiPanelSection' },
+      })
+      seen_section = true
+    elseif row.kind == 'state' then
+      push_line({
+        text = ' ' .. row.text .. ' ',
+        meta = { highlight = row.highlight or 'CosmicUiPanelStateInfo' },
+      })
+    elseif row.kind == 'action' then
+      action_idx = action_idx + 1
+      push_line({ text = ' ' .. row.text .. ' ' })
+      action_line_by_idx[action_idx] = #line_specs
+    else
+      push_line({ text = ' ' .. (row.text or '') .. ' ' })
+    end
+  end
+
+  if model.footer and #model.footer > 0 then
+    if #line_specs > 0 then
+      push_line({ text = '' })
+    end
+
+    local footer_text, spans = M.render_footer(model.footer)
+    for _, span in ipairs(spans) do
+      span.start_col = span.start_col + 1
+      span.end_col = span.end_col + 1
+    end
+
+    push_line({
+      text = ' ' .. footer_text .. ' ',
+      meta = { spans = spans },
+    })
+  end
+
+  local width = math.max(raw_max_width, (opts.min_width or 30) + 2)
+  local height = math.max(#line_specs, 1)
+
+  if opts.clamp_size then
+    width, height = opts.clamp_size(width, height)
+  end
+
+  local lines = {}
+  local highlights_by_line = {}
+
+  for idx, spec in ipairs(line_specs) do
+    lines[idx] = finalize_standard_text(spec, width)
+    if spec.meta then
+      highlights_by_line[idx] = spec.meta
+    end
+  end
+
+  return {
+    width = width,
+    height = height,
+    lines = lines,
+    highlights = highlights_by_line,
+    action_line_by_idx = action_line_by_idx,
+  }
 end
 
 M.restore_focus = window.restore_focus

--- a/lua/cosmic-ui/ui/panel.lua
+++ b/lua/cosmic-ui/ui/panel.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.build(opts)
+  opts = opts or {}
+
+  return {
+    title = opts.title,
+    subtitle = opts.subtitle,
+    footer = opts.footer or {},
+    rows = opts.rows or {},
+    selected = opts.selected,
+  }
+end
+
+return M

--- a/lua/cosmic-ui/ui/panel.lua
+++ b/lua/cosmic-ui/ui/panel.lua
@@ -64,6 +64,14 @@ local function normalize_rows(rows)
   return normalized
 end
 
+local function normalize_layout(layout)
+  if layout == 'compact' then
+    return 'compact'
+  end
+
+  return 'standard'
+end
+
 local function normalize_selected(selected, rows)
   if type(selected) ~= 'number' then
     return nil
@@ -82,6 +90,7 @@ function M.build(opts)
   local rows = normalize_rows(opts.rows)
 
   return {
+    layout = normalize_layout(opts.layout),
     title = opts.title or '',
     subtitle = opts.subtitle or '',
     title_highlight = 'CosmicUiPanelTitle',

--- a/lua/cosmic-ui/ui/panel.lua
+++ b/lua/cosmic-ui/ui/panel.lua
@@ -1,15 +1,88 @@
+local highlights = require('cosmic-ui.ui.highlights')
+local window = require('cosmic-ui.window')
+
 local M = {}
+
+local function normalize_footer_entry(entry)
+  if type(entry) == 'table' then
+    return {
+      key = entry.key or entry[1] or '',
+      text = entry.text or entry[2] or '',
+    }
+  end
+
+  local raw = tostring(entry or '')
+  local key, text = raw:match('^([^:]+):%s*(.+)$')
+  if key then
+    return { key = key, text = text }
+  end
+
+  return { key = raw, text = '' }
+end
+
+local function normalize_footer(entries)
+  local footer = {}
+
+  for _, entry in ipairs(entries or {}) do
+    table.insert(footer, normalize_footer_entry(entry))
+  end
+
+  return footer
+end
+
+local function normalize_row(row)
+  local normalized = vim.tbl_extend('force', {}, row or {})
+
+  if normalized.kind == 'state' then
+    normalized.state = normalized.state or 'info'
+    normalized.text = normalized.text or ''
+    normalized.highlight = highlights.group_for_state(normalized.state)
+  end
+
+  return normalized
+end
+
+local function normalize_rows(rows)
+  local normalized = {}
+
+  for _, row in ipairs(rows or {}) do
+    table.insert(normalized, normalize_row(row))
+  end
+
+  return normalized
+end
+
+local function normalize_selected(selected, rows)
+  if type(selected) ~= 'number' then
+    return nil
+  end
+
+  selected = math.floor(selected)
+  if selected < 1 or selected > #rows then
+    return nil
+  end
+
+  return selected
+end
 
 function M.build(opts)
   opts = opts or {}
+  local rows = normalize_rows(opts.rows)
 
   return {
-    title = opts.title,
-    subtitle = opts.subtitle,
-    footer = opts.footer or {},
-    rows = opts.rows or {},
-    selected = opts.selected,
+    title = opts.title or '',
+    subtitle = opts.subtitle or '',
+    footer = normalize_footer(opts.footer),
+    rows = rows,
+    selected = normalize_selected(opts.selected, rows),
   }
 end
+
+function M.prepare(opts)
+  highlights.ensure()
+  return M.build(opts)
+end
+
+M.restore_focus = window.restore_focus
 
 return M

--- a/lua/cosmic-ui/ui/panel.lua
+++ b/lua/cosmic-ui/ui/panel.lua
@@ -8,16 +8,28 @@ local function normalize_footer_entry(entry)
     return {
       key = entry.key or entry[1] or '',
       text = entry.text or entry[2] or '',
+      key_highlight = entry.key_highlight or 'CosmicUiPanelHintKey',
+      text_highlight = entry.text_highlight or 'CosmicUiPanelHintText',
     }
   end
 
   local raw = tostring(entry or '')
   local key, text = raw:match('^([^:]+):%s*(.+)$')
   if key then
-    return { key = key, text = text }
+    return {
+      key = key,
+      text = text,
+      key_highlight = 'CosmicUiPanelHintKey',
+      text_highlight = 'CosmicUiPanelHintText',
+    }
   end
 
-  return { key = raw, text = '' }
+  return {
+    key = raw,
+    text = '',
+    key_highlight = 'CosmicUiPanelHintKey',
+    text_highlight = 'CosmicUiPanelHintText',
+  }
 end
 
 local function normalize_footer(entries)
@@ -72,6 +84,8 @@ function M.build(opts)
   return {
     title = opts.title or '',
     subtitle = opts.subtitle or '',
+    title_highlight = 'CosmicUiPanelTitle',
+    subtitle_highlight = 'CosmicUiPanelSubtitle',
     footer = normalize_footer(opts.footer),
     rows = rows,
     selected = normalize_selected(opts.selected, rows),

--- a/lua/cosmic-ui/ui/states.lua
+++ b/lua/cosmic-ui/ui/states.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.empty(text)
+  return { kind = "state", state = "empty", text = text }
+end
+
+return M

--- a/lua/cosmic-ui/ui/states.lua
+++ b/lua/cosmic-ui/ui/states.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.empty(text)
-  return { kind = "state", state = "empty", text = text }
+  return { kind = 'state', state = 'empty', text = text }
 end
 
 return M

--- a/lua/cosmic-ui/window.lua
+++ b/lua/cosmic-ui/window.lua
@@ -49,6 +49,12 @@ M.set_float_config = function(win, config)
   vim.api.nvim_win_set_config(win, config)
 end
 
+M.restore_focus = function(win)
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_set_current_win(win)
+  end
+end
+
 M.safe_close_win = function(win)
   if win and vim.api.nvim_win_is_valid(win) then
     pcall(vim.api.nvim_win_close, win, true)

--- a/plugin/cosmic-ui.lua
+++ b/plugin/cosmic-ui.lua
@@ -12,16 +12,16 @@ _G.CosmicUI = require('cosmic-ui')
 
 vim.api.nvim_create_user_command('CosmicRename', function()
   require('cosmic-ui').rename.open()
-end, {})
+end, { desc = 'Open the Cosmic rename prompt' })
 
 vim.api.nvim_create_user_command('CosmicCodeActions', function()
   require('cosmic-ui').codeactions.open()
-end, {})
+end, { desc = 'Open the Cosmic code action panel' })
 
 vim.api.nvim_create_user_command('CosmicFormatters', function()
   require('cosmic-ui').formatters.open()
-end, {})
+end, { desc = 'Open the Cosmic formatter panel' })
 
 vim.api.nvim_create_user_command('CosmicFormat', function()
   require('cosmic-ui').formatters.format()
-end, {})
+end, { desc = 'Format the current buffer with Cosmic formatter routing' })

--- a/plugin/cosmic-ui.lua
+++ b/plugin/cosmic-ui.lua
@@ -1,5 +1,5 @@
-if vim.fn.has("nvim-0.11") ~= 1 then
-  error("Sorry this plugin only supports Neovim version >= v0.11")
+if vim.fn.has('nvim-0.11') ~= 1 then
+  error('Sorry this plugin only supports Neovim version >= v0.11')
   return
 end
 
@@ -9,3 +9,19 @@ end
 
 vim.g.loaded_cosmic_ui = 1
 _G.CosmicUI = require('cosmic-ui')
+
+vim.api.nvim_create_user_command('CosmicRename', function()
+  require('cosmic-ui').rename.open()
+end, {})
+
+vim.api.nvim_create_user_command('CosmicCodeActions', function()
+  require('cosmic-ui').codeactions.open()
+end, {})
+
+vim.api.nvim_create_user_command('CosmicFormatters', function()
+  require('cosmic-ui').formatters.open()
+end, {})
+
+vim.api.nvim_create_user_command('CosmicFormat', function()
+  require('cosmic-ui').formatters.format()
+end, {})

--- a/readme.md
+++ b/readme.md
@@ -15,8 +15,8 @@ _Warning: Under heavy development_
 Cosmic-UI is a simple wrapper around specific vim functionality. Built in order to provide a quick and easy way to create a Cosmic UI experience with Neovim!
 
 - Rename floating popup & file change notification
-- Code Actions
-- Formatter toggles (LSP + Conform.nvim)
+- Code action panel with grouped, ordered results
+- Formatter panel for LSP + Conform.nvim toggles and formatting
 
 ## 📷 Screenshots
 
@@ -111,6 +111,13 @@ Neovim help:
 - `:help cosmic-ui.codeactions`
 - `:help cosmic-ui.formatters`
 
+Optional commands:
+
+- `:CosmicRename`
+- `:CosmicCodeActions`
+- `:CosmicFormatters`
+- `:CosmicFormat`
+
 ### Feature modules
 
 - `rename`: Cursor-local rename input that dispatches LSP rename requests.  
@@ -148,6 +155,8 @@ vim.keymap.set("n", "gn", function()
 end, { silent = true, desc = "Rename" })
 ```
 
+Optional command: `:CosmicRename`
+
 ### Codeactions
 
 ```lua
@@ -159,6 +168,8 @@ vim.keymap.set("v", "<leader>ga", function()
   require("cosmic-ui").codeactions.range()
 end, { silent = true, desc = "Range code actions" })
 ```
+
+Optional command: `:CosmicCodeActions`
 
 ### Formatters
 
@@ -175,6 +186,11 @@ vim.keymap.set("n", "<leader>fm", function()
   require("cosmic-ui").formatters.format()
 end, { silent = true, desc = "Format buffer" })
 ```
+
+Optional commands:
+
+- `:CosmicFormatters`
+- `:CosmicFormat`
 
 Formatting behavior:
 - If Conform.nvim is installed and conform backend is enabled, `format()` uses Conform.

--- a/tests/codeactions/model_spec.lua
+++ b/tests/codeactions/model_spec.lua
@@ -1,66 +1,69 @@
-describe("cosmic-ui.codeactions.ui.model", function()
-  it("builds grouped rows with a stable title and action count", function()
-    local model = require("cosmic-ui.codeactions.ui.model")
+describe('cosmic-ui.codeactions.ui.model', function()
+  it('builds grouped rows with a stable title and action count', function()
+    local model = require('cosmic-ui.codeactions.ui.model')
     local built = model.build({
       [2] = {
-        client = { id = 2, name = "zeta" },
+        client = { id = 2, name = 'zeta' },
         result = {
-          { title = "Fix trailing spaces" },
+          { title = 'Fix trailing spaces' },
         },
       },
       [1] = {
-        client = { id = 1, name = "alpha" },
+        client = { id = 1, name = 'alpha' },
         result = {
-          { title = "Organize Imports" },
-          { title = "Extract Function" },
+          { title = 'Organize Imports' },
+          { title = 'Extract Function' },
         },
       },
     })
 
-    assert.are.equal("Code Actions", built.title)
-    assert.are.equal("3 actions", built.subtitle)
+    assert.are.equal('Code Actions', built.title)
+    assert.are.equal('3 actions', built.subtitle)
     assert.are.equal(3, #built.actions)
-    assert.are.same({
-      "section",
-      "action",
-      "action",
-      "section",
-      "action",
-    }, vim.tbl_map(function(row)
-      return row.kind
-    end, built.rows))
-    assert.are.equal("alpha", built.rows[1].text)
-    assert.are.equal("zeta", built.rows[4].text)
+    assert.are.same(
+      {
+        'section',
+        'action',
+        'action',
+        'section',
+        'action',
+      },
+      vim.tbl_map(function(row)
+        return row.kind
+      end, built.rows)
+    )
+    assert.are.equal('alpha', built.rows[1].text)
+    assert.are.equal('zeta', built.rows[4].text)
   end)
 
-  it("builds an explicit empty state when no actions are available", function()
-    local model = require("cosmic-ui.codeactions.ui.model")
+  it('builds an explicit empty state when no actions are available', function()
+    local model = require('cosmic-ui.codeactions.ui.model')
     local built = model.build({
       [1] = {
-        client = { id = 1, name = "lua_ls" },
+        client = { id = 1, name = 'lua_ls' },
         result = {},
       },
     })
 
     assert.are.equal(0, #built.actions)
-    assert.are.equal("0 actions", built.subtitle)
+    assert.are.equal('0 actions', built.subtitle)
     assert.are.same({
-      kind = "state",
-      state = "empty",
-      text = "No code actions available",
+      kind = 'state',
+      state = 'empty',
+      text = 'No code actions available',
     }, built.rows[1])
   end)
 
-  it("keeps successful actions visible when one client errors", function()
-    local model = require("cosmic-ui.codeactions.ui.model")
+  it('keeps successful actions visible when one client errors', function()
+    local model = require('cosmic-ui.codeactions.ui.model')
     local built = model.build({
       [1] = {
-        client = { id = 1, name = "lua_ls" },
-        result = { { title = "Organize Imports" } },
+        client = { id = 1, name = 'lua_ls' },
+        result = { { title = 'Organize Imports' } },
       },
       [2] = {
-        client = { id = 2, name = "eslint" },
-        error = { code = -1, message = "request failed" },
+        client = { id = 2, name = 'eslint' },
+        error = { code = -1, message = 'request failed' },
         result = nil,
       },
     })
@@ -69,9 +72,9 @@ describe("cosmic-ui.codeactions.ui.model", function()
     assert.are.equal(true, built.has_partial_error)
     assert.are.equal(1, built.error_count)
     assert.are.same({
-      kind = "state",
-      state = "warn",
-      text = "1 source failed to return code actions",
+      kind = 'state',
+      state = 'warn',
+      text = '1 source failed to return code actions',
     }, built.rows[1])
   end)
 end)

--- a/tests/codeactions/model_spec.lua
+++ b/tests/codeactions/model_spec.lua
@@ -1,5 +1,5 @@
 describe('cosmic-ui.codeactions.ui.model', function()
-  it('builds grouped rows with a stable title and action count', function()
+  it('builds grouped headerless rows for available actions', function()
     local model = require('cosmic-ui.codeactions.ui.model')
     local built = model.build({
       [2] = {
@@ -17,8 +17,8 @@ describe('cosmic-ui.codeactions.ui.model', function()
       },
     })
 
-    assert.are.equal('Code Actions', built.title)
-    assert.are.equal('3 actions', built.subtitle)
+    assert.is_nil(built.title)
+    assert.is_nil(built.subtitle)
     assert.are.equal(3, #built.actions)
     assert.are.same(
       {
@@ -46,7 +46,8 @@ describe('cosmic-ui.codeactions.ui.model', function()
     })
 
     assert.are.equal(0, #built.actions)
-    assert.are.equal('0 actions', built.subtitle)
+    assert.is_nil(built.title)
+    assert.is_nil(built.subtitle)
     assert.are.same({
       kind = 'state',
       state = 'empty',

--- a/tests/codeactions/model_spec.lua
+++ b/tests/codeactions/model_spec.lua
@@ -1,0 +1,77 @@
+describe("cosmic-ui.codeactions.ui.model", function()
+  it("builds grouped rows with a stable title and action count", function()
+    local model = require("cosmic-ui.codeactions.ui.model")
+    local built = model.build({
+      [2] = {
+        client = { id = 2, name = "zeta" },
+        result = {
+          { title = "Fix trailing spaces" },
+        },
+      },
+      [1] = {
+        client = { id = 1, name = "alpha" },
+        result = {
+          { title = "Organize Imports" },
+          { title = "Extract Function" },
+        },
+      },
+    })
+
+    assert.are.equal("Code Actions", built.title)
+    assert.are.equal("3 actions", built.subtitle)
+    assert.are.equal(3, #built.actions)
+    assert.are.same({
+      "section",
+      "action",
+      "action",
+      "section",
+      "action",
+    }, vim.tbl_map(function(row)
+      return row.kind
+    end, built.rows))
+    assert.are.equal("alpha", built.rows[1].text)
+    assert.are.equal("zeta", built.rows[4].text)
+  end)
+
+  it("builds an explicit empty state when no actions are available", function()
+    local model = require("cosmic-ui.codeactions.ui.model")
+    local built = model.build({
+      [1] = {
+        client = { id = 1, name = "lua_ls" },
+        result = {},
+      },
+    })
+
+    assert.are.equal(0, #built.actions)
+    assert.are.equal("0 actions", built.subtitle)
+    assert.are.same({
+      kind = "state",
+      state = "empty",
+      text = "No code actions available",
+    }, built.rows[1])
+  end)
+
+  it("keeps successful actions visible when one client errors", function()
+    local model = require("cosmic-ui.codeactions.ui.model")
+    local built = model.build({
+      [1] = {
+        client = { id = 1, name = "lua_ls" },
+        result = { { title = "Organize Imports" } },
+      },
+      [2] = {
+        client = { id = 2, name = "eslint" },
+        error = { code = -1, message = "request failed" },
+        result = nil,
+      },
+    })
+
+    assert.are.equal(1, #built.actions)
+    assert.are.equal(true, built.has_partial_error)
+    assert.are.equal(1, built.error_count)
+    assert.are.same({
+      kind = "state",
+      state = "warn",
+      text = "1 source failed to return code actions",
+    }, built.rows[1])
+  end)
+end)

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -1,5 +1,30 @@
 describe('cosmic-ui.codeactions.ui', function()
   local lifecycle
+  local function collect_highlights(bufnr, ns)
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+    local collected = {}
+
+    for _, mark in ipairs(marks) do
+      table.insert(collected, {
+        lnum = mark[2],
+        col = mark[3],
+        end_col = mark[4].end_col,
+        hl_group = mark[4].hl_group,
+      })
+    end
+
+    return collected
+  end
+
+  local function has_highlight(highlights, expected)
+    for _, highlight in ipairs(highlights) do
+      if vim.deep_equal(highlight, expected) then
+        return true
+      end
+    end
+
+    return false
+  end
 
   before_each(function()
     lifecycle = require('cosmic-ui.codeactions.ui.lifecycle')
@@ -118,6 +143,228 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatBorder:Identifier', 1, true) ~= nil)
     assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatTitle:Title', 1, true) ~= nil)
     assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatFooter:Question', 1, true) ~= nil)
+  end)
+
+  it('renders footer text and highlight spans with the shared panel footer output', function()
+    local panel = require('cosmic-ui.ui.panel')
+    local render = require('cosmic-ui.codeactions.ui.render')
+    local buf = vim.api.nvim_create_buf(false, true)
+    local win = vim.api.nvim_get_current_win()
+    local ui = {
+      buf = buf,
+      win = win,
+      ns = vim.api.nvim_create_namespace('cosmic-ui-codeactions-footer-spec'),
+      min_width = 30,
+      model = { actions = {} },
+      panel = panel.build({
+        footer = {
+          'Enter:apply',
+          'Esc:close',
+        },
+      }),
+    }
+
+    render.render(ui)
+
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local extmarks = collect_highlights(buf, ui.ns)
+
+    assert.are.same({ ' Enter:apply  Esc:close ' }, lines)
+    assert.is_true(has_highlight(extmarks, {
+      lnum = 0,
+      col = 1,
+      end_col = 6,
+      hl_group = 'CosmicUiPanelHintKey',
+    }))
+    assert.is_true(has_highlight(extmarks, {
+      lnum = 0,
+      col = 7,
+      end_col = 12,
+      hl_group = 'CosmicUiPanelHintText',
+    }))
+    assert.is_true(has_highlight(extmarks, {
+      lnum = 0,
+      col = 14,
+      end_col = 17,
+      hl_group = 'CosmicUiPanelHintKey',
+    }))
+    assert.is_true(has_highlight(extmarks, {
+      lnum = 0,
+      col = 18,
+      end_col = 23,
+      hl_group = 'CosmicUiPanelHintText',
+    }))
+
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end)
+
+  it('keeps the standard code-actions render output unchanged after shared prep extraction', function()
+    local panel = require('cosmic-ui.ui.panel')
+    local render = require('cosmic-ui.codeactions.ui.render')
+    local buf = vim.api.nvim_create_buf(false, true)
+    local win = vim.api.nvim_open_win(buf, false, {
+      relative = 'editor',
+      row = 1,
+      col = 1,
+      width = 40,
+      height = 8,
+      style = 'minimal',
+      border = 'single',
+    })
+    local ui = {
+      buf = buf,
+      win = win,
+      ns = vim.api.nvim_create_namespace('cosmic-ui-codeactions-standard-render-spec'),
+      min_width = 30,
+      selected = 1,
+      border = {},
+      model = {
+        actions = {
+          { text = 'Fix A' },
+          { text = 'Fix B' },
+        },
+      },
+      panel = panel.build({
+        footer = {
+          'Enter:apply',
+          'Esc:close',
+        },
+        rows = {
+          { kind = 'section', text = 'alpha' },
+          { kind = 'action', text = 'Fix A' },
+          { kind = 'separator', text = 'beta' },
+          { kind = 'action', text = 'Fix B' },
+        },
+      }),
+    }
+
+    render.render(ui)
+
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local extmarks = collect_highlights(buf, ui.ns)
+
+    assert.are.same({
+      '             alpha              ',
+      ' Fix A ',
+      '',
+      '              beta              ',
+      ' Fix B ',
+      '',
+      ' Enter:apply  Esc:close ',
+    }, lines)
+    assert.is_true(has_highlight(extmarks, {
+      lnum = 0,
+      col = 0,
+      end_col = 0,
+      hl_group = 'CosmicUiPanelSection',
+    }))
+    assert.is_true(has_highlight(extmarks, {
+      lnum = 3,
+      col = 0,
+      end_col = 0,
+      hl_group = 'CosmicUiPanelSection',
+    }))
+    assert.are.same({
+      [1] = 2,
+      [2] = 5,
+    }, ui.action_line_by_idx)
+
+    vim.api.nvim_win_close(win, true)
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end)
+
+  it('updates selection without rebuilding layout state', function()
+    local panel = require('cosmic-ui.ui.panel')
+    local render = require('cosmic-ui.codeactions.ui.render')
+    local buf = vim.api.nvim_create_buf(false, true)
+    local win = vim.api.nvim_open_win(buf, false, {
+      relative = 'editor',
+      row = 1,
+      col = 1,
+      width = 30,
+      height = 6,
+      style = 'minimal',
+      border = 'single',
+    })
+    local ui = {
+      buf = buf,
+      win = win,
+      ns = vim.api.nvim_create_namespace('cosmic-ui-codeactions-selection-spec'),
+      min_width = 30,
+      selected = 1,
+      border = {},
+      model = {
+        actions = {
+          { text = 'Fix A' },
+          { text = 'Fix B' },
+        },
+      },
+      panel = panel.build({
+        rows = {
+          { kind = 'section', text = 'lua_ls' },
+          { kind = 'action', text = 'Fix A' },
+          { kind = 'action', text = 'Fix B' },
+        },
+      }),
+    }
+
+    render.render(ui)
+
+    local lines_before = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local cfg_before = vim.api.nvim_win_get_config(win)
+    local original_strdisplaywidth = vim.fn.strdisplaywidth
+    local original_set_lines = vim.api.nvim_buf_set_lines
+    local original_clear_namespace = vim.api.nvim_buf_clear_namespace
+    local original_add_highlight = vim.api.nvim_buf_add_highlight
+    local original_set_config = vim.api.nvim_win_set_config
+
+    vim.fn.strdisplaywidth = function()
+      error('selection update should not remeasure widths')
+    end
+    vim.api.nvim_buf_set_lines = function()
+      error('selection update should not rebuild line specs')
+    end
+    vim.api.nvim_buf_clear_namespace = function()
+      error('selection update should not clear existing highlights')
+    end
+    vim.api.nvim_buf_add_highlight = function()
+      error('selection update should not rebuild highlights')
+    end
+    vim.api.nvim_win_set_config = function(target, cfg)
+      assert.is_nil(cfg.width)
+      assert.is_nil(cfg.height)
+      assert.is_nil(cfg.row)
+      assert.is_nil(cfg.col)
+      return original_set_config(target, cfg)
+    end
+
+    local ok, err = pcall(function()
+      ui.selected = 2
+      render.update_selection(ui)
+    end)
+
+    vim.fn.strdisplaywidth = original_strdisplaywidth
+    vim.api.nvim_buf_set_lines = original_set_lines
+    vim.api.nvim_buf_clear_namespace = original_clear_namespace
+    vim.api.nvim_buf_add_highlight = original_add_highlight
+    vim.api.nvim_win_set_config = original_set_config
+
+    if not ok then
+      error(err)
+    end
+
+    local cfg_after = vim.api.nvim_win_get_config(win)
+
+    assert.are.same(lines_before, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+    assert.are.equal(cfg_before.width, cfg_after.width)
+    assert.are.equal(cfg_before.height, cfg_after.height)
+    assert.are.equal(cfg_before.row, cfg_after.row)
+    assert.are.equal(cfg_before.col, cfg_after.col)
+    assert.are.equal('(2/2)', cfg_after.footer[1][1])
+    assert.are.same({ ui.action_line_by_idx[2], 0 }, vim.api.nvim_win_get_cursor(win))
+
+    vim.api.nvim_win_close(win, true)
+    vim.api.nvim_buf_delete(buf, { force = true })
   end)
 
   it('does not advertise numeric direct picks for small action lists', function()
@@ -372,6 +619,47 @@ describe('cosmic-ui.codeactions.ui', function()
     end
 
     assert.are.same({}, numeric_lhs)
+  end)
+
+  it('routes selection navigation through the lightweight update path', function()
+    local input = require('cosmic-ui.codeactions.ui.input')
+    local original_buf = vim.api.nvim_get_current_buf()
+    local buf = vim.api.nvim_create_buf(false, true)
+    local ui = {
+      buf = buf,
+      selected = 1,
+      model = {
+        actions = {
+          { text = 'First action' },
+          { text = 'Second action' },
+        },
+      },
+    }
+    local calls = {}
+
+    vim.api.nvim_set_current_buf(buf)
+
+    input.set_keymaps(ui, {
+      submit_action = function() end,
+    }, {
+      close_fn = function() end,
+      render_fn = function()
+        table.insert(calls, 'render')
+      end,
+      update_selection_fn = function(target_ui)
+        table.insert(calls, 'update')
+        assert.are.equal(ui, target_ui)
+      end,
+    })
+
+    vim.api.nvim_feedkeys('j', 'xt', false)
+    vim.cmd('redraw')
+
+    vim.api.nvim_set_current_buf(original_buf)
+    vim.api.nvim_buf_delete(buf, { force = true })
+
+    assert.are.equal(2, ui.selected)
+    assert.are.same({ 'update' }, calls)
   end)
 end)
 

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -1,22 +1,6 @@
 describe('cosmic-ui.codeactions.ui', function()
   local lifecycle
 
-  local function collect_highlights(bufnr, ns)
-    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
-    local collected = {}
-
-    for _, mark in ipairs(marks) do
-      table.insert(collected, {
-        lnum = mark[2],
-        col = mark[3],
-        end_col = mark[4].end_col,
-        hl_group = mark[4].hl_group,
-      })
-    end
-
-    return collected
-  end
-
   before_each(function()
     lifecycle = require('cosmic-ui.codeactions.ui.lifecycle')
     lifecycle.close_current()
@@ -80,47 +64,23 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.are.same({ '<Esc>' }, seen)
   end)
 
-  it('highlights footer helpers from the first character', function()
+  it('does not render in-buffer footer helper rows', function()
     local ui = require('cosmic-ui.codeactions.ui')
 
     ui.open({
       [1] = {
         client = { id = 1, name = 'lua_ls' },
-        result = {},
+        result = {
+          { title = 'Fix' },
+        },
       },
     }, {})
 
     local state = lifecycle.get_state()
     local lines = vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false)
-    local marks = collect_highlights(state.ui.buf, state.ui.ns)
-    local footer_marks = {}
 
-    assert.are.equal(' Esc:close ', lines[#lines])
-
-    for _, mark in ipairs(marks) do
-      if mark.lnum == #lines - 1 then
-        table.insert(footer_marks, mark)
-      end
-    end
-
-    table.sort(footer_marks, function(left, right)
-      return left.col < right.col
-    end)
-
-    assert.are.same({
-      {
-        lnum = #lines - 1,
-        col = 1,
-        end_col = 4,
-        hl_group = 'CosmicUiPanelHintKey',
-      },
-      {
-        lnum = #lines - 1,
-        col = 5,
-        end_col = 10,
-        hl_group = 'CosmicUiPanelHintText',
-      },
-    }, footer_marks)
+    assert.is_false(vim.tbl_contains(lines, ' Esc:close '))
+    assert.is_false(vim.tbl_contains(lines, ' Enter:apply  Esc:close '))
   end)
 
   it('preserves configured min width and border metadata on the float', function()

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -160,6 +160,25 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatFooter:Question', 1, true) ~= nil)
   end)
 
+  it('does not advertise numeric direct picks for small action lists', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    ui.open({
+      [1] = {
+        client = { id = 1, name = 'lua_ls' },
+        result = {
+          { title = 'Fix A' },
+          { title = 'Fix B' },
+        },
+      },
+    }, {})
+
+    local state = lifecycle.get_state()
+    local lines = vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false)
+
+    assert.is_false(vim.tbl_contains(lines, ' 1-9:pick '))
+  end)
+
   it('does not reopen a dismissed loading panel when ready-state results arrive for the same request', function()
     local ui = require('cosmic-ui.codeactions.ui')
 
@@ -264,13 +283,11 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_nil(lifecycle.get_state().ui)
   end)
 
-  it('supports numeric direct picks for the first visible actions', function()
+  it('does not install numeric direct-pick keymaps', function()
     local input = require('cosmic-ui.codeactions.ui.input')
 
     local buf = vim.api.nvim_create_buf(false, true)
     local win = vim.api.nvim_get_current_win()
-    local selected
-    local closed = 0
 
     local ui = {
       buf = buf,
@@ -286,22 +303,22 @@ describe('cosmic-ui.codeactions.ui', function()
     }
 
     input.set_keymaps(ui, {
-      submit_action = function(action)
-        selected = action.text
-      end,
+      submit_action = function() end,
     }, {
-      close_fn = function()
-        closed = closed + 1
-      end,
+      close_fn = function() end,
       render_fn = function() end,
     })
 
-    vim.api.nvim_set_current_win(win)
-    vim.api.nvim_set_current_buf(buf)
-    vim.api.nvim_feedkeys('2', 'xt', false)
+    local keymaps = vim.api.nvim_buf_get_keymap(buf, 'n')
+    local numeric_lhs = {}
 
-    assert.are.equal('Second action', selected)
-    assert.are.equal(1, closed)
+    for _, keymap in ipairs(keymaps) do
+      if string.match(keymap.lhs, '^%d$') then
+        table.insert(numeric_lhs, keymap.lhs)
+      end
+    end
+
+    assert.are.same({}, numeric_lhs)
   end)
 end)
 

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -1,8 +1,8 @@
-describe("cosmic-ui.codeactions.ui", function()
+describe('cosmic-ui.codeactions.ui', function()
   local lifecycle
 
   before_each(function()
-    lifecycle = require("cosmic-ui.codeactions.ui.lifecycle")
+    lifecycle = require('cosmic-ui.codeactions.ui.lifecycle')
     lifecycle.close_current()
   end)
 
@@ -10,12 +10,12 @@ describe("cosmic-ui.codeactions.ui", function()
     lifecycle.close_current()
   end)
 
-  it("opens an explicit empty-state panel when no actions are available", function()
-    local ui = require("cosmic-ui.codeactions.ui")
+  it('opens an explicit empty-state panel when no actions are available', function()
+    local ui = require('cosmic-ui.codeactions.ui')
 
     ui.open({
       [1] = {
-        client = { id = 1, name = "lua_ls" },
+        client = { id = 1, name = 'lua_ls' },
         result = {},
       },
     }, {})
@@ -23,28 +23,30 @@ describe("cosmic-ui.codeactions.ui", function()
     local state = lifecycle.get_state()
     assert.is_not_nil(state.ui)
     assert.is_true(vim.api.nvim_buf_is_valid(state.ui.buf))
-    assert.is_true(vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), " No code actions available "))
+    assert.is_true(
+      vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), ' No code actions available ')
+    )
   end)
 
-  it("preserves configured min width and border metadata on the float", function()
-    local ui = require("cosmic-ui.codeactions.ui")
+  it('preserves configured min width and border metadata on the float', function()
+    local ui = require('cosmic-ui.codeactions.ui')
 
     ui.open({
       [1] = {
-        client = { id = 1, name = "lua_ls" },
+        client = { id = 1, name = 'lua_ls' },
         result = {
-          { title = "Fix" },
+          { title = 'Fix' },
         },
       },
     }, {
       min_width = 50,
       border = {
-        style = "single",
-        title = "Custom Actions",
-        title_align = "left",
-        title_hl = "Title",
-        bottom_hl = "Question",
-        highlight = "Identifier",
+        style = 'single',
+        title = 'Custom Actions',
+        title_align = 'left',
+        title_hl = 'Title',
+        bottom_hl = 'Question',
+        highlight = 'Identifier',
       },
     })
 
@@ -52,19 +54,19 @@ describe("cosmic-ui.codeactions.ui", function()
     local cfg = vim.api.nvim_win_get_config(state.ui.win)
 
     assert.are.equal(52, cfg.width)
-    assert.are.equal("table", type(cfg.border))
-    assert.are.equal("┌", cfg.border[1])
-    assert.are.equal("Custom Actions", cfg.title[1][1])
-    assert.are.equal("left", cfg.title_pos)
-    assert.are.equal("(1/1)", cfg.footer[1][1])
-    assert.are.equal("right", cfg.footer_pos)
-    assert.is_true(string.find(vim.wo[state.ui.win].winhl, "FloatBorder:Identifier", 1, true) ~= nil)
-    assert.is_true(string.find(vim.wo[state.ui.win].winhl, "FloatTitle:Title", 1, true) ~= nil)
-    assert.is_true(string.find(vim.wo[state.ui.win].winhl, "FloatFooter:Question", 1, true) ~= nil)
+    assert.are.equal('table', type(cfg.border))
+    assert.are.equal('┌', cfg.border[1])
+    assert.are.equal('Custom Actions', cfg.title[1][1])
+    assert.are.equal('left', cfg.title_pos)
+    assert.are.equal('(1/1)', cfg.footer[1][1])
+    assert.are.equal('right', cfg.footer_pos)
+    assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatBorder:Identifier', 1, true) ~= nil)
+    assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatTitle:Title', 1, true) ~= nil)
+    assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatFooter:Question', 1, true) ~= nil)
   end)
 
-  it("supports numeric direct picks for the first visible actions", function()
-    local input = require("cosmic-ui.codeactions.ui.input")
+  it('supports numeric direct picks for the first visible actions', function()
+    local input = require('cosmic-ui.codeactions.ui.input')
 
     local buf = vim.api.nvim_create_buf(false, true)
     local win = vim.api.nvim_get_current_win()
@@ -77,9 +79,9 @@ describe("cosmic-ui.codeactions.ui", function()
       selected = 1,
       model = {
         actions = {
-          { text = "First action" },
-          { text = "Second action" },
-          { text = "Third action" },
+          { text = 'First action' },
+          { text = 'Second action' },
+          { text = 'Third action' },
         },
       },
     }
@@ -97,16 +99,16 @@ describe("cosmic-ui.codeactions.ui", function()
 
     vim.api.nvim_set_current_win(win)
     vim.api.nvim_set_current_buf(buf)
-    vim.api.nvim_feedkeys("2", "xt", false)
+    vim.api.nvim_feedkeys('2', 'xt', false)
 
-    assert.are.equal("Second action", selected)
+    assert.are.equal('Second action', selected)
     assert.are.equal(1, closed)
   end)
 end)
 
-describe("cosmic-ui.codeactions.request", function()
-  it("reports loading before ready and keeps request metadata", function()
-    local request = require("cosmic-ui.codeactions.request")
+describe('cosmic-ui.codeactions.request', function()
+  it('reports loading before ready and keeps request metadata', function()
+    local request = require('cosmic-ui.codeactions.request')
     local original_get_namespace = vim.lsp.diagnostic.get_namespace
     local original_diagnostic_get = vim.diagnostic.get
     local original_make_range_params = vim.lsp.util.make_range_params
@@ -126,16 +128,16 @@ describe("cosmic-ui.codeactions.request", function()
     local clients = {
       {
         id = 1,
-        name = "lua_ls",
-        offset_encoding = "utf-16",
+        name = 'lua_ls',
+        offset_encoding = 'utf-16',
         request = function(_, _, _, cb)
           callbacks[1] = cb
         end,
       },
       {
         id = 2,
-        name = "eslint",
-        offset_encoding = "utf-16",
+        name = 'eslint',
+        offset_encoding = 'utf-16',
         request = function(_, _, _, cb)
           callbacks[2] = cb
         end,
@@ -146,7 +148,7 @@ describe("cosmic-ui.codeactions.request", function()
       request.collect({
         bufnr = 0,
         clients = clients,
-        user_opts = { params = { context = { only = { "quickfix" } } } },
+        user_opts = { params = { context = { only = { 'quickfix' } } } },
         on_complete = function(state)
           table.insert(seen, {
             status = state.status,
@@ -157,8 +159,8 @@ describe("cosmic-ui.codeactions.request", function()
         end,
       })
 
-      callbacks[1](nil, { { title = "Fix one" } })
-      callbacks[2](nil, { { title = "Fix two" } })
+      callbacks[1](nil, { { title = 'Fix one' } })
+      callbacks[2](nil, { { title = 'Fix two' } })
     end)
 
     vim.lsp.diagnostic.get_namespace = original_get_namespace
@@ -168,13 +170,13 @@ describe("cosmic-ui.codeactions.request", function()
     assert.is_true(ok, err)
     assert.are.same({
       {
-        status = "loading",
+        status = 'loading',
         total_clients = 2,
         completed_clients = 0,
         response_count = 0,
       },
       {
-        status = "ready",
+        status = 'ready',
         total_clients = 2,
         completed_clients = 2,
         response_count = 2,

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -190,38 +190,79 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_nil(lifecycle.get_state().ui)
   end)
 
-  it(
-    'does not reopen a loading panel after lifecycle close when ready-state results arrive for the same request',
-    function()
-      local ui = require('cosmic-ui.codeactions.ui')
+  it('reopens after a loading panel loses focus while the request is still in flight', function()
+    local ui = require('cosmic-ui.codeactions.ui')
 
-      local request_state = {
-        status = 'loading',
-        responses = {},
-        total_clients = 1,
-        completed_clients = 0,
-      }
+    local request_state = {
+      status = 'loading',
+      responses = {},
+      total_clients = 1,
+      completed_clients = 0,
+    }
 
-      ui.open(request_state, {})
-      assert.is_not_nil(lifecycle.get_state().ui)
+    ui.open(request_state, {})
+    assert.is_not_nil(lifecycle.get_state().ui)
 
-      lifecycle.close_current()
-      assert.is_nil(lifecycle.get_state().ui)
+    local buf = lifecycle.get_state().ui.buf
+    vim.api.nvim_exec_autocmds('BufLeave', { buffer = buf })
 
-      request_state.status = 'ready'
-      request_state.completed_clients = 1
-      request_state.responses[1] = {
+    assert.is_nil(lifecycle.get_state().ui)
+    assert.is_false(lifecycle.is_request_dismissed(request_state))
+
+    request_state.status = 'ready'
+    request_state.completed_clients = 1
+    request_state.responses[1] = {
+      client = { id = 1, name = 'lua_ls' },
+      result = {
+        { title = 'Fix' },
+      },
+    }
+
+    ui.open(request_state, {})
+
+    local state = lifecycle.get_state()
+    assert.is_not_nil(state.ui)
+    assert.is_true(vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), ' 1. Fix '))
+  end)
+
+  it('keeps explicit dismiss semantics when a ready panel is reused for a new loading request', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    ui.open({
+      [1] = {
         client = { id = 1, name = 'lua_ls' },
         result = {
-          { title = 'Fix' },
+          { title = 'Fix A' },
         },
-      }
+      },
+    }, {})
 
-      ui.open(request_state, {})
+    local request_state = {
+      status = 'loading',
+      responses = {},
+      total_clients = 1,
+      completed_clients = 0,
+    }
 
-      assert.is_nil(lifecycle.get_state().ui)
-    end
-  )
+    ui.open(request_state, {})
+    assert.are.equal(request_state, lifecycle.get_state().ui.request_state)
+
+    ui.close()
+    assert.is_nil(lifecycle.get_state().ui)
+
+    request_state.status = 'ready'
+    request_state.completed_clients = 1
+    request_state.responses[1] = {
+      client = { id = 1, name = 'lua_ls' },
+      result = {
+        { title = 'Fix B' },
+      },
+    }
+
+    ui.open(request_state, {})
+
+    assert.is_nil(lifecycle.get_state().ui)
+  end)
 
   it('supports numeric direct picks for the first visible actions', function()
     local input = require('cosmic-ui.codeactions.ui.input')
@@ -340,5 +381,75 @@ describe('cosmic-ui.codeactions.request', function()
         response_count = 2,
       },
     }, seen)
+  end)
+
+  it('freezes the source buffer before the loading callback changes current buffer', function()
+    local request = require('cosmic-ui.codeactions.request')
+    local original_get_namespace = vim.lsp.diagnostic.get_namespace
+    local original_diagnostic_get = vim.diagnostic.get
+    local original_make_range_params = vim.lsp.util.make_range_params
+    local seen = {}
+
+    vim.lsp.diagnostic.get_namespace = function()
+      return 0
+    end
+    vim.diagnostic.get = function()
+      return {}
+    end
+    vim.lsp.util.make_range_params = function(_, _)
+      return {
+        textDocument = {
+          uri = vim.uri_from_bufnr(vim.api.nvim_get_current_buf()),
+        },
+        context = {},
+      }
+    end
+
+    local ok, err = pcall(function()
+      vim.cmd('enew!')
+      local source_buf = vim.api.nvim_get_current_buf()
+      local source_name = vim.fn.tempname() .. '.ts'
+      vim.api.nvim_buf_set_name(source_buf, source_name)
+      local scratch_buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_name(scratch_buf, 'scratch://loading')
+
+      request.collect({
+        bufnr = 0,
+        clients = {
+          {
+            id = 1,
+            name = 'lua_ls',
+            offset_encoding = 'utf-16',
+            request = function(_, _, params, cb, bufnr)
+              table.insert(seen, {
+                bufnr = bufnr,
+                current_buf = vim.api.nvim_get_current_buf(),
+                uri = params.textDocument and params.textDocument.uri or nil,
+              })
+              cb(nil, {})
+            end,
+          },
+        },
+        on_complete = function(state)
+          if state.status == 'loading' then
+            vim.api.nvim_set_current_buf(scratch_buf)
+          end
+        end,
+      })
+
+      assert.are.same({
+        {
+          bufnr = source_buf,
+          current_buf = scratch_buf,
+          uri = vim.uri_from_bufnr(source_buf),
+        },
+      }, seen)
+    end)
+
+    vim.lsp.diagnostic.get_namespace = original_get_namespace
+    vim.diagnostic.get = original_diagnostic_get
+    vim.lsp.util.make_range_params = original_make_range_params
+
+    assert.is_true(ok, err)
   end)
 end)

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -1,6 +1,22 @@
 describe('cosmic-ui.codeactions.ui', function()
   local lifecycle
 
+  local function collect_highlights(bufnr, ns)
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+    local collected = {}
+
+    for _, mark in ipairs(marks) do
+      table.insert(collected, {
+        lnum = mark[2],
+        col = mark[3],
+        end_col = mark[4].end_col,
+        hl_group = mark[4].hl_group,
+      })
+    end
+
+    return collected
+  end
+
   before_each(function()
     lifecycle = require('cosmic-ui.codeactions.ui.lifecycle')
     lifecycle.close_current()
@@ -26,6 +42,49 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_true(
       vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), ' No code actions available ')
     )
+  end)
+
+  it('highlights footer helpers from the first character', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    ui.open({
+      [1] = {
+        client = { id = 1, name = 'lua_ls' },
+        result = {},
+      },
+    }, {})
+
+    local state = lifecycle.get_state()
+    local lines = vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false)
+    local marks = collect_highlights(state.ui.buf, state.ui.ns)
+    local footer_marks = {}
+
+    assert.are.equal(' Esc:close ', lines[#lines])
+
+    for _, mark in ipairs(marks) do
+      if mark.lnum == #lines - 1 then
+        table.insert(footer_marks, mark)
+      end
+    end
+
+    table.sort(footer_marks, function(left, right)
+      return left.col < right.col
+    end)
+
+    assert.are.same({
+      {
+        lnum = #lines - 1,
+        col = 1,
+        end_col = 4,
+        hl_group = 'CosmicUiPanelHintKey',
+      },
+      {
+        lnum = #lines - 1,
+        col = 5,
+        end_col = 10,
+        hl_group = 'CosmicUiPanelHintText',
+      },
+    }, footer_marks)
   end)
 
   it('preserves configured min width and border metadata on the float', function()

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -179,6 +179,28 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_false(vim.tbl_contains(lines, ' 1-9:pick '))
   end)
 
+  it('renders action rows without numeric prefixes', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    ui.open({
+      [1] = {
+        client = { id = 1, name = 'lua_ls' },
+        result = {
+          { title = 'Fix A' },
+          { title = 'Fix B' },
+        },
+      },
+    }, {})
+
+    local state = lifecycle.get_state()
+    local lines = vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false)
+
+    assert.is_true(vim.tbl_contains(lines, ' Fix A '))
+    assert.is_true(vim.tbl_contains(lines, ' Fix B '))
+    assert.is_false(vim.tbl_contains(lines, ' 1. Fix A '))
+    assert.is_false(vim.tbl_contains(lines, ' 2. Fix B '))
+  end)
+
   it('does not reopen a dismissed loading panel when ready-state results arrive for the same request', function()
     local ui = require('cosmic-ui.codeactions.ui')
 
@@ -241,7 +263,7 @@ describe('cosmic-ui.codeactions.ui', function()
 
     local state = lifecycle.get_state()
     assert.is_not_nil(state.ui)
-    assert.is_true(vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), ' 1. Fix '))
+    assert.is_true(vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), ' Fix '))
   end)
 
   it('keeps explicit dismiss semantics when a ready panel is reused for a new loading request', function()

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -65,6 +65,36 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_true(string.find(vim.wo[state.ui.win].winhl, 'FloatFooter:Question', 1, true) ~= nil)
   end)
 
+  it('does not reopen a dismissed loading panel when ready-state results arrive for the same request', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    local request_state = {
+      status = 'loading',
+      responses = {},
+      total_clients = 1,
+      completed_clients = 0,
+    }
+
+    ui.open(request_state, {})
+    assert.is_not_nil(lifecycle.get_state().ui)
+
+    ui.close()
+    assert.is_nil(lifecycle.get_state().ui)
+
+    request_state.status = 'ready'
+    request_state.completed_clients = 1
+    request_state.responses[1] = {
+      client = { id = 1, name = 'lua_ls' },
+      result = {
+        { title = 'Fix' },
+      },
+    }
+
+    ui.open(request_state, {})
+
+    assert.is_nil(lifecycle.get_state().ui)
+  end)
+
   it('supports numeric direct picks for the first visible actions', function()
     local input = require('cosmic-ui.codeactions.ui.input')
 

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -157,7 +157,7 @@ describe('cosmic-ui.codeactions.ui', function()
 
     assert.is_false(vim.tbl_contains(lines, ' Code Actions '))
     assert.is_false(vim.tbl_contains(lines, ' 2 actions '))
-    assert.is_true(vim.tbl_contains(lines, ' lua_ls '))
+    assert.is_true(vim.tbl_contains(vim.tbl_map(vim.trim, lines), 'lua_ls'))
     assert.is_true(vim.tbl_contains(lines, ' Fix A '))
     assert.is_true(vim.tbl_contains(lines, ' Fix B '))
   end)
@@ -182,6 +182,54 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_true(vim.tbl_contains(lines, ' Fix B '))
     assert.is_false(vim.tbl_contains(lines, ' 1. Fix A '))
     assert.is_false(vim.tbl_contains(lines, ' 2. Fix B '))
+  end)
+
+  it('centers section headers and inserts one blank row between client sections', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    ui.open({
+      [2] = {
+        client = { id = 2, name = 'zeta' },
+        result = {
+          { title = 'Fix trailing spaces' },
+        },
+      },
+      [1] = {
+        client = { id = 1, name = 'alpha' },
+        result = {
+          { title = 'Organize Imports' },
+          { title = 'Extract Function' },
+        },
+      },
+    }, {})
+
+    local state = lifecycle.get_state()
+    local lines = vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false)
+
+    local function find_trimmed(text)
+      for idx, line in ipairs(lines) do
+        if vim.trim(line) == text then
+          return idx, line
+        end
+      end
+      return nil, nil
+    end
+
+    local alpha_idx, alpha_line = find_trimmed('alpha')
+    local zeta_idx, zeta_line = find_trimmed('zeta')
+
+    assert.is_not_nil(alpha_idx)
+    assert.is_not_nil(zeta_idx)
+    assert.are.equal('', lines[zeta_idx - 1])
+
+    local function assert_centered(line, label)
+      local left_pad, text, right_pad = line:match('^(%s*)(.-)(%s*)$')
+      assert.are.equal(label, text)
+      assert.is_true(math.abs(#left_pad - #right_pad) <= 1)
+    end
+
+    assert_centered(alpha_line, 'alpha')
+    assert_centered(zeta_line, 'zeta')
   end)
 
   it('does not reopen a dismissed loading panel when ready-state results arrive for the same request', function()

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -1,0 +1,68 @@
+describe("cosmic-ui.codeactions.ui", function()
+  local lifecycle
+
+  before_each(function()
+    lifecycle = require("cosmic-ui.codeactions.ui.lifecycle")
+    lifecycle.close_current()
+  end)
+
+  after_each(function()
+    lifecycle.close_current()
+  end)
+
+  it("opens an explicit empty-state panel when no actions are available", function()
+    local ui = require("cosmic-ui.codeactions.ui")
+
+    ui.open({
+      [1] = {
+        client = { id = 1, name = "lua_ls" },
+        result = {},
+      },
+    }, {})
+
+    local state = lifecycle.get_state()
+    assert.is_not_nil(state.ui)
+    assert.is_true(vim.api.nvim_buf_is_valid(state.ui.buf))
+    assert.is_true(vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), " No code actions available "))
+  end)
+
+  it("supports numeric direct picks for the first visible actions", function()
+    local input = require("cosmic-ui.codeactions.ui.input")
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    local win = vim.api.nvim_get_current_win()
+    local selected
+    local closed = 0
+
+    local ui = {
+      buf = buf,
+      win = win,
+      selected = 1,
+      model = {
+        actions = {
+          { text = "First action" },
+          { text = "Second action" },
+          { text = "Third action" },
+        },
+      },
+    }
+
+    input.set_keymaps(ui, {
+      submit_action = function(action)
+        selected = action.text
+      end,
+    }, {
+      close_fn = function()
+        closed = closed + 1
+      end,
+      render_fn = function() end,
+    })
+
+    vim.api.nvim_set_current_win(win)
+    vim.api.nvim_set_current_buf(buf)
+    vim.api.nvim_feedkeys("2", "xt", false)
+
+    assert.are.equal("Second action", selected)
+    assert.are.equal(1, closed)
+  end)
+end)

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -44,6 +44,42 @@ describe('cosmic-ui.codeactions.ui', function()
     )
   end)
 
+  it('requests normal-mode normalization when opened outside normal mode', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+    local original_mode = vim.fn.mode
+    local original_input = vim.api.nvim_input
+    local seen = {}
+
+    vim.fn.mode = function()
+      return 'i'
+    end
+    vim.api.nvim_input = function(keys)
+      table.insert(seen, keys)
+      return ''
+    end
+
+    local ok, err = pcall(function()
+      ui.open({
+        [1] = {
+          client = { id = 1, name = 'lua_ls' },
+          result = {
+            { title = 'Fix' },
+          },
+        },
+      }, {})
+    end)
+
+    vim.fn.mode = original_mode
+    vim.api.nvim_input = original_input
+
+    if not ok then
+      error(err)
+    end
+
+    ui.close()
+    assert.are.same({ '<Esc>' }, seen)
+  end)
+
   it('highlights footer helpers from the first character', function()
     local ui = require('cosmic-ui.codeactions.ui')
 

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -26,6 +26,43 @@ describe("cosmic-ui.codeactions.ui", function()
     assert.is_true(vim.tbl_contains(vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false), " No code actions available "))
   end)
 
+  it("preserves configured min width and border metadata on the float", function()
+    local ui = require("cosmic-ui.codeactions.ui")
+
+    ui.open({
+      [1] = {
+        client = { id = 1, name = "lua_ls" },
+        result = {
+          { title = "Fix" },
+        },
+      },
+    }, {
+      min_width = 50,
+      border = {
+        style = "single",
+        title = "Custom Actions",
+        title_align = "left",
+        title_hl = "Title",
+        bottom_hl = "Question",
+        highlight = "Identifier",
+      },
+    })
+
+    local state = lifecycle.get_state()
+    local cfg = vim.api.nvim_win_get_config(state.ui.win)
+
+    assert.are.equal(52, cfg.width)
+    assert.are.equal("table", type(cfg.border))
+    assert.are.equal("┌", cfg.border[1])
+    assert.are.equal("Custom Actions", cfg.title[1][1])
+    assert.are.equal("left", cfg.title_pos)
+    assert.are.equal("(1/1)", cfg.footer[1][1])
+    assert.are.equal("right", cfg.footer_pos)
+    assert.is_true(string.find(vim.wo[state.ui.win].winhl, "FloatBorder:Identifier", 1, true) ~= nil)
+    assert.is_true(string.find(vim.wo[state.ui.win].winhl, "FloatTitle:Title", 1, true) ~= nil)
+    assert.is_true(string.find(vim.wo[state.ui.win].winhl, "FloatFooter:Question", 1, true) ~= nil)
+  end)
+
   it("supports numeric direct picks for the first visible actions", function()
     local input = require("cosmic-ui.codeactions.ui.input")
 
@@ -64,5 +101,84 @@ describe("cosmic-ui.codeactions.ui", function()
 
     assert.are.equal("Second action", selected)
     assert.are.equal(1, closed)
+  end)
+end)
+
+describe("cosmic-ui.codeactions.request", function()
+  it("reports loading before ready and keeps request metadata", function()
+    local request = require("cosmic-ui.codeactions.request")
+    local original_get_namespace = vim.lsp.diagnostic.get_namespace
+    local original_diagnostic_get = vim.diagnostic.get
+    local original_make_range_params = vim.lsp.util.make_range_params
+    local callbacks = {}
+    local seen = {}
+
+    vim.lsp.diagnostic.get_namespace = function()
+      return 0
+    end
+    vim.diagnostic.get = function()
+      return {}
+    end
+    vim.lsp.util.make_range_params = function()
+      return { context = {} }
+    end
+
+    local clients = {
+      {
+        id = 1,
+        name = "lua_ls",
+        offset_encoding = "utf-16",
+        request = function(_, _, _, cb)
+          callbacks[1] = cb
+        end,
+      },
+      {
+        id = 2,
+        name = "eslint",
+        offset_encoding = "utf-16",
+        request = function(_, _, _, cb)
+          callbacks[2] = cb
+        end,
+      },
+    }
+
+    local ok, err = pcall(function()
+      request.collect({
+        bufnr = 0,
+        clients = clients,
+        user_opts = { params = { context = { only = { "quickfix" } } } },
+        on_complete = function(state)
+          table.insert(seen, {
+            status = state.status,
+            total_clients = state.total_clients,
+            completed_clients = state.completed_clients,
+            response_count = vim.tbl_count(state.responses),
+          })
+        end,
+      })
+
+      callbacks[1](nil, { { title = "Fix one" } })
+      callbacks[2](nil, { { title = "Fix two" } })
+    end)
+
+    vim.lsp.diagnostic.get_namespace = original_get_namespace
+    vim.diagnostic.get = original_diagnostic_get
+    vim.lsp.util.make_range_params = original_make_range_params
+
+    assert.is_true(ok, err)
+    assert.are.same({
+      {
+        status = "loading",
+        total_clients = 2,
+        completed_clients = 0,
+        response_count = 0,
+      },
+      {
+        status = "ready",
+        total_clients = 2,
+        completed_clients = 2,
+        response_count = 2,
+      },
+    }, seen)
   end)
 end)

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -179,6 +179,29 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_false(vim.tbl_contains(lines, ' 1-9:pick '))
   end)
 
+  it('does not render duplicate in-buffer title or action-count rows', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    ui.open({
+      [1] = {
+        client = { id = 1, name = 'lua_ls' },
+        result = {
+          { title = 'Fix A' },
+          { title = 'Fix B' },
+        },
+      },
+    }, {})
+
+    local state = lifecycle.get_state()
+    local lines = vim.api.nvim_buf_get_lines(state.ui.buf, 0, -1, false)
+
+    assert.is_false(vim.tbl_contains(lines, ' Code Actions '))
+    assert.is_false(vim.tbl_contains(lines, ' 2 actions '))
+    assert.is_true(vim.tbl_contains(lines, ' lua_ls '))
+    assert.is_true(vim.tbl_contains(lines, ' Fix A '))
+    assert.is_true(vim.tbl_contains(lines, ' Fix B '))
+  end)
+
   it('renders action rows without numeric prefixes', function()
     local ui = require('cosmic-ui.codeactions.ui')
 

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -95,6 +95,36 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_nil(lifecycle.get_state().ui)
   end)
 
+  it('does not reopen a loading panel after lifecycle close when ready-state results arrive for the same request', function()
+    local ui = require('cosmic-ui.codeactions.ui')
+
+    local request_state = {
+      status = 'loading',
+      responses = {},
+      total_clients = 1,
+      completed_clients = 0,
+    }
+
+    ui.open(request_state, {})
+    assert.is_not_nil(lifecycle.get_state().ui)
+
+    lifecycle.close_current()
+    assert.is_nil(lifecycle.get_state().ui)
+
+    request_state.status = 'ready'
+    request_state.completed_clients = 1
+    request_state.responses[1] = {
+      client = { id = 1, name = 'lua_ls' },
+      result = {
+        { title = 'Fix' },
+      },
+    }
+
+    ui.open(request_state, {})
+
+    assert.is_nil(lifecycle.get_state().ui)
+  end)
+
   it('supports numeric direct picks for the first visible actions', function()
     local input = require('cosmic-ui.codeactions.ui.input')
 

--- a/tests/codeactions/ui_spec.lua
+++ b/tests/codeactions/ui_spec.lua
@@ -95,35 +95,38 @@ describe('cosmic-ui.codeactions.ui', function()
     assert.is_nil(lifecycle.get_state().ui)
   end)
 
-  it('does not reopen a loading panel after lifecycle close when ready-state results arrive for the same request', function()
-    local ui = require('cosmic-ui.codeactions.ui')
+  it(
+    'does not reopen a loading panel after lifecycle close when ready-state results arrive for the same request',
+    function()
+      local ui = require('cosmic-ui.codeactions.ui')
 
-    local request_state = {
-      status = 'loading',
-      responses = {},
-      total_clients = 1,
-      completed_clients = 0,
-    }
+      local request_state = {
+        status = 'loading',
+        responses = {},
+        total_clients = 1,
+        completed_clients = 0,
+      }
 
-    ui.open(request_state, {})
-    assert.is_not_nil(lifecycle.get_state().ui)
+      ui.open(request_state, {})
+      assert.is_not_nil(lifecycle.get_state().ui)
 
-    lifecycle.close_current()
-    assert.is_nil(lifecycle.get_state().ui)
+      lifecycle.close_current()
+      assert.is_nil(lifecycle.get_state().ui)
 
-    request_state.status = 'ready'
-    request_state.completed_clients = 1
-    request_state.responses[1] = {
-      client = { id = 1, name = 'lua_ls' },
-      result = {
-        { title = 'Fix' },
-      },
-    }
+      request_state.status = 'ready'
+      request_state.completed_clients = 1
+      request_state.responses[1] = {
+        client = { id = 1, name = 'lua_ls' },
+        result = {
+          { title = 'Fix' },
+        },
+      }
 
-    ui.open(request_state, {})
+      ui.open(request_state, {})
 
-    assert.is_nil(lifecycle.get_state().ui)
-  end)
+      assert.is_nil(lifecycle.get_state().ui)
+    end
+  )
 
   it('supports numeric direct picks for the first visible actions', function()
     local input = require('cosmic-ui.codeactions.ui.input')

--- a/tests/commands_spec.lua
+++ b/tests/commands_spec.lua
@@ -1,12 +1,101 @@
 describe('cosmic-ui commands', function()
-  it('registers optional Cosmic commands', function()
+  local original_cosmic
+  local original_global
+  local command_names = {
+    'CosmicRename',
+    'CosmicCodeActions',
+    'CosmicFormatters',
+    'CosmicFormat',
+  }
+
+  local function delete_commands()
+    for _, name in ipairs(command_names) do
+      pcall(vim.api.nvim_del_user_command, name)
+    end
+  end
+
+  before_each(function()
+    original_cosmic = package.loaded['cosmic-ui']
+    original_global = rawget(_G, 'CosmicUI')
+
+    delete_commands()
+    package.loaded['cosmic-ui'] = nil
+    _G.CosmicUI = nil
+    vim.g.loaded_cosmic_ui = nil
+  end)
+
+  after_each(function()
+    delete_commands()
+    package.loaded['cosmic-ui'] = original_cosmic
+    _G.CosmicUI = original_global
+    vim.g.loaded_cosmic_ui = nil
+  end)
+
+  it('registers optional Cosmic commands only after plugin load and dispatches to the matching wrappers', function()
+    local before = vim.api.nvim_get_commands({})
+
+    assert.is_nil(before.CosmicRename)
+    assert.is_nil(before.CosmicCodeActions)
+    assert.is_nil(before.CosmicFormatters)
+    assert.is_nil(before.CosmicFormat)
+
+    local calls = {
+      rename = 0,
+      codeactions = 0,
+      formatters = 0,
+      format = 0,
+    }
+
+    package.loaded['cosmic-ui'] = {
+      rename = {
+        open = function()
+          calls.rename = calls.rename + 1
+        end,
+      },
+      codeactions = {
+        open = function()
+          calls.codeactions = calls.codeactions + 1
+        end,
+      },
+      formatters = {
+        open = function()
+          calls.formatters = calls.formatters + 1
+        end,
+        format = function()
+          calls.format = calls.format + 1
+        end,
+      },
+    }
+
     vim.cmd('runtime plugin/cosmic-ui.lua')
 
-    local commands = vim.api.nvim_get_commands({})
+    local after = vim.api.nvim_get_commands({})
 
-    assert.is_truthy(commands.CosmicRename)
-    assert.is_truthy(commands.CosmicCodeActions)
-    assert.is_truthy(commands.CosmicFormatters)
-    assert.is_truthy(commands.CosmicFormat)
+    assert.is_truthy(after.CosmicRename)
+    assert.is_truthy(after.CosmicCodeActions)
+    assert.is_truthy(after.CosmicFormatters)
+    assert.is_truthy(after.CosmicFormat)
+
+    assert.matches('Open the Cosmic rename prompt', vim.fn.execute('command CosmicRename'), 1, true)
+    assert.matches('Open the Cosmic code action panel', vim.fn.execute('command CosmicCodeActions'), 1, true)
+    assert.matches('Open the Cosmic formatter panel', vim.fn.execute('command CosmicFormatters'), 1, true)
+    assert.matches(
+      'Format the current buffer with Cosmic formatter routing',
+      vim.fn.execute('command CosmicFormat'),
+      1,
+      true
+    )
+
+    vim.cmd('CosmicRename')
+    vim.cmd('CosmicCodeActions')
+    vim.cmd('CosmicFormatters')
+    vim.cmd('CosmicFormat')
+
+    assert.are.same({
+      rename = 1,
+      codeactions = 1,
+      formatters = 1,
+      format = 1,
+    }, calls)
   end)
 end)

--- a/tests/commands_spec.lua
+++ b/tests/commands_spec.lua
@@ -1,0 +1,12 @@
+describe('cosmic-ui commands', function()
+  it('registers optional Cosmic commands', function()
+    vim.cmd('runtime plugin/cosmic-ui.lua')
+
+    local commands = vim.api.nvim_get_commands({})
+
+    assert.is_truthy(commands.CosmicRename)
+    assert.is_truthy(commands.CosmicCodeActions)
+    assert.is_truthy(commands.CosmicFormatters)
+    assert.is_truthy(commands.CosmicFormat)
+  end)
+end)

--- a/tests/formatters/rows_spec.lua
+++ b/tests/formatters/rows_spec.lua
@@ -1,0 +1,103 @@
+describe("cosmic-ui.formatters.ui.rows", function()
+  local function find_row(rows, id)
+    for _, row in ipairs(rows) do
+      if row.id == id then
+        return row
+      end
+    end
+
+    return nil
+  end
+
+  it("renders conform-unavailable rows with explanatory text", function()
+    local rows = require("cosmic-ui.formatters.ui.rows")
+    local built = rows.build_rows({
+      conform = { available = false, reason = "conform unavailable", formatters = {}, fallback = {} },
+      lsp_clients = {},
+    }, { conform = "C", lsp = "L", file = "F", filetype = "lua" }, { unavailable = "!" })
+
+    local row = find_row(built, "conform_unavailable")
+    assert.are.same({
+      id = "conform_unavailable",
+      text = "! C Conform unavailable: conform unavailable",
+      toggleable = false,
+      kind = "info",
+      status = "unavailable",
+      status_icon = "!",
+      source_icon = "C",
+      reason = "conform unavailable",
+    }, row)
+  end)
+
+  it("renders empty backend rows with explicit source labels", function()
+    local rows = require("cosmic-ui.formatters.ui.rows")
+    local built = rows.build_rows({
+      conform = {
+        available = true,
+        reason = nil,
+        formatters = {},
+        fallback = { display_global_mode = "fallback" },
+      },
+      lsp_clients = {},
+    }, { conform = "C", lsp = "L", file = "F", filetype = "lua" }, { unavailable = "!" })
+
+    assert.are.same({
+      id = "conform_empty",
+      text = "! C Conform: no formatters available",
+      toggleable = false,
+      kind = "info",
+      status = "unavailable",
+      status_icon = "!",
+      source_icon = "C",
+    }, find_row(built, "conform_empty"))
+
+    assert.are.same({
+      id = "lsp_empty",
+      text = "! L LSP: no attached clients",
+      toggleable = false,
+      kind = "info",
+      status = "unavailable",
+      status_icon = "!",
+      source_icon = "L",
+    }, find_row(built, "lsp_empty"))
+  end)
+
+  it("stores shared section metadata separately from section text", function()
+    local rows = require("cosmic-ui.formatters.ui.rows")
+    local built = rows.build_rows({
+      conform = {
+        available = true,
+        reason = nil,
+        formatters = {
+          { name = "stylua", enabled = true },
+        },
+        fallback = {
+          display_global_mode = "never",
+          display_specific_mode = "fallback",
+        },
+      },
+      lsp_clients = {
+        { name = "lua_ls", available = true, enabled = true },
+      },
+    }, { conform = "C", lsp = "L", file = "F", filetype = "lua" }, {
+      enabled = "+",
+      disabled = "-",
+      unavailable = "!",
+    })
+
+    assert.are.same({
+      id = "section_conform",
+      text = "Conform",
+      toggleable = false,
+      kind = "section",
+    }, find_row(built, "section_conform"))
+
+    assert.are.same({
+      id = "section_lsp",
+      text = "LSP",
+      subtitle = "fallback",
+      toggleable = false,
+      kind = "section",
+    }, find_row(built, "section_lsp"))
+  end)
+end)

--- a/tests/formatters/rows_spec.lua
+++ b/tests/formatters/rows_spec.lua
@@ -126,6 +126,7 @@ describe('cosmic-ui.formatters.ui.rows', function()
     local highlights = require('cosmic-ui.formatters.ui.highlights')
     local input = require('cosmic-ui.formatters.ui.input')
     local render = require('cosmic-ui.formatters.ui.render')
+    local ui_state = {}
 
     local buf = vim.api.nvim_create_buf(false, true)
     local ui = {
@@ -147,7 +148,7 @@ describe('cosmic-ui.formatters.ui.rows', function()
       close_fn = function()
         error('render should not close the panel')
       end,
-      ui_state = {},
+      ui_state = ui_state,
       constants = constants,
       highlights = highlights,
       rows = {
@@ -199,10 +200,11 @@ describe('cosmic-ui.formatters.ui.rows', function()
       },
     }
 
+    highlights.ensure(ui_state, constants.highlight_links)
     render.render(ui, handlers, deps)
 
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    local extmarks = collect_highlights(buf, deps.ui_state.ns)
+    local extmarks = collect_highlights(buf, ui_state.ns)
     local has_footer_key_hl = false
     local has_footer_text_hl = false
     local has_subtitle_hl = false
@@ -240,5 +242,78 @@ describe('cosmic-ui.formatters.ui.rows', function()
     assert.is_true(has_footer_key_hl)
     assert.is_true(has_footer_text_hl)
     assert.is_true(has_subtitle_hl)
+  end)
+
+  it('reuses the existing formatter highlight namespace during rerenders', function()
+    local constants = require('cosmic-ui.formatters.constants')
+    local render = require('cosmic-ui.formatters.ui.render')
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    local ensure_calls = 0
+    local seen_ns = {}
+    local ui = {
+      buf = buf,
+      win = vim.api.nvim_get_current_win(),
+      scope = 'buffer',
+      target_bufnr = 0,
+      selected = nil,
+      rows = {},
+      footer = {},
+    }
+    local handlers = {
+      status_fn = function()
+        return {}
+      end,
+    }
+    local deps = {
+      logger = {},
+      close_fn = function()
+        error('render should not close the panel')
+      end,
+      ui_state = { ns = 77 },
+      constants = constants,
+      highlights = {
+        ensure = function()
+          ensure_calls = ensure_calls + 1
+          return 88
+        end,
+        apply = function(_, ns)
+          table.insert(seen_ns, ns)
+        end,
+      },
+      rows = {
+        get_devicons = function()
+          return {}
+        end,
+        make_icons = function()
+          return {
+            file = 'F',
+            filetype = 'lua',
+          }
+        end,
+        build_rows = function()
+          return {}
+        end,
+      },
+      window = {
+        centered_float_config = function(width, height)
+          return {
+            row = 1,
+            col = 1,
+            width = width,
+            height = height,
+          }
+        end,
+        set_float_config = function() end,
+      },
+    }
+
+    render.render(ui, handlers, deps)
+    render.render(ui, handlers, deps)
+
+    vim.api.nvim_buf_delete(buf, { force = true })
+
+    assert.are.equal(0, ensure_calls)
+    assert.are.same({ 77, 77 }, seen_ns)
   end)
 end)

--- a/tests/formatters/rows_spec.lua
+++ b/tests/formatters/rows_spec.lua
@@ -9,6 +9,26 @@ describe("cosmic-ui.formatters.ui.rows", function()
     return nil
   end
 
+  local function rstrip(text)
+    return (text:gsub("%s+$", ""))
+  end
+
+  local function collect_highlights(bufnr, ns)
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+    local collected = {}
+
+    for _, mark in ipairs(marks) do
+      table.insert(collected, {
+        lnum = mark[2],
+        col = mark[3],
+        end_col = mark[4].end_col,
+        hl_group = mark[4].hl_group,
+      })
+    end
+
+    return collected
+  end
+
   it("renders conform-unavailable rows with explanatory text", function()
     local rows = require("cosmic-ui.formatters.ui.rows")
     local built = rows.build_rows({
@@ -99,5 +119,123 @@ describe("cosmic-ui.formatters.ui.rows", function()
       toggleable = false,
       kind = "section",
     }, find_row(built, "section_lsp"))
+  end)
+
+  it("renders section subtitles and shared footer highlights through the formatter panel", function()
+    local constants = require("cosmic-ui.formatters.constants")
+    local highlights = require("cosmic-ui.formatters.ui.highlights")
+    local input = require("cosmic-ui.formatters.ui.input")
+    local render = require("cosmic-ui.formatters.ui.render")
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    local ui = {
+      buf = buf,
+      win = vim.api.nvim_get_current_win(),
+      scope = "buffer",
+      target_bufnr = 0,
+      selected = nil,
+      rows = {},
+      footer = input.footer_entries(),
+    }
+    local handlers = {
+      status_fn = function()
+        return {}
+      end,
+    }
+    local deps = {
+      logger = {},
+      close_fn = function()
+        error("render should not close the panel")
+      end,
+      ui_state = {},
+      constants = constants,
+      highlights = highlights,
+      rows = {
+        get_devicons = function()
+          return {}
+        end,
+        make_icons = function()
+          return {
+            file = "F",
+            filetype = "lua",
+          }
+        end,
+        build_rows = function()
+          return {
+            {
+              id = "section_lsp",
+              kind = "section",
+              text = "LSP",
+              subtitle = "fallback",
+              toggleable = false,
+            },
+            {
+              id = "lsp_lua_ls",
+              kind = "item",
+              text = "+ L lua_ls",
+              toggleable = true,
+              status = "enabled",
+              status_icon = "+",
+              source_icon = "L",
+              action = {
+                kind = "item",
+                source = "lsp",
+                name = "lua_ls",
+              },
+            },
+          }
+        end,
+      },
+      window = {
+        centered_float_config = function(width, height)
+          return {
+            row = 1,
+            col = 1,
+            width = width,
+            height = height,
+          }
+        end,
+        set_float_config = function() end,
+      },
+    }
+
+    render.render(ui, handlers, deps)
+
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local extmarks = collect_highlights(buf, deps.ui_state.ns)
+    local has_footer_key_hl = false
+    local has_footer_text_hl = false
+    local has_subtitle_hl = false
+
+    assert.are.equal(" LSP  fallback", rstrip(lines[ui.rows[1].lnum]))
+    assert.are.equal(" Tab:toggle+next  s:scope  r:reset  a:toggle all  f:format  q:close", rstrip(lines[ui.footer_lnum]))
+    assert.are.same({
+      highlight = "CosmicUiPanelHintKey",
+      start_col = 1,
+      end_col = 4,
+    }, ui.footer_spans[1])
+    assert.are.same({
+      highlight = "CosmicUiPanelHintText",
+      start_col = 5,
+      end_col = 16,
+    }, ui.footer_spans[2])
+
+    for _, mark in ipairs(extmarks) do
+      if mark.lnum == ui.footer_lnum - 1 and mark.hl_group == "CosmicUiPanelHintKey" then
+        has_footer_key_hl = true
+      end
+      if mark.lnum == ui.footer_lnum - 1 and mark.hl_group == "CosmicUiPanelHintText" then
+        has_footer_text_hl = true
+      end
+      if mark.lnum == ui.rows[1].lnum - 1 and mark.hl_group == "CosmicUiFmtSubtitle" then
+        has_subtitle_hl = true
+      end
+    end
+
+    vim.api.nvim_buf_delete(buf, { force = true })
+
+    assert.is_true(has_footer_key_hl)
+    assert.is_true(has_footer_text_hl)
+    assert.is_true(has_subtitle_hl)
   end)
 end)

--- a/tests/formatters/rows_spec.lua
+++ b/tests/formatters/rows_spec.lua
@@ -1,4 +1,4 @@
-describe("cosmic-ui.formatters.ui.rows", function()
+describe('cosmic-ui.formatters.ui.rows', function()
   local function find_row(rows, id)
     for _, row in ipairs(rows) do
       if row.id == id then
@@ -10,7 +10,7 @@ describe("cosmic-ui.formatters.ui.rows", function()
   end
 
   local function rstrip(text)
-    return (text:gsub("%s+$", ""))
+    return (text:gsub('%s+$', ''))
   end
 
   local function collect_highlights(bufnr, ns)
@@ -29,109 +29,109 @@ describe("cosmic-ui.formatters.ui.rows", function()
     return collected
   end
 
-  it("renders conform-unavailable rows with explanatory text", function()
-    local rows = require("cosmic-ui.formatters.ui.rows")
+  it('renders conform-unavailable rows with explanatory text', function()
+    local rows = require('cosmic-ui.formatters.ui.rows')
     local built = rows.build_rows({
-      conform = { available = false, reason = "conform unavailable", formatters = {}, fallback = {} },
+      conform = { available = false, reason = 'conform unavailable', formatters = {}, fallback = {} },
       lsp_clients = {},
-    }, { conform = "C", lsp = "L", file = "F", filetype = "lua" }, { unavailable = "!" })
+    }, { conform = 'C', lsp = 'L', file = 'F', filetype = 'lua' }, { unavailable = '!' })
 
-    local row = find_row(built, "conform_unavailable")
+    local row = find_row(built, 'conform_unavailable')
     assert.are.same({
-      id = "conform_unavailable",
-      text = "! C Conform unavailable: conform unavailable",
+      id = 'conform_unavailable',
+      text = '! C Conform unavailable: conform unavailable',
       toggleable = false,
-      kind = "info",
-      status = "unavailable",
-      status_icon = "!",
-      source_icon = "C",
-      reason = "conform unavailable",
+      kind = 'info',
+      status = 'unavailable',
+      status_icon = '!',
+      source_icon = 'C',
+      reason = 'conform unavailable',
     }, row)
   end)
 
-  it("renders empty backend rows with explicit source labels", function()
-    local rows = require("cosmic-ui.formatters.ui.rows")
+  it('renders empty backend rows with explicit source labels', function()
+    local rows = require('cosmic-ui.formatters.ui.rows')
     local built = rows.build_rows({
       conform = {
         available = true,
         reason = nil,
         formatters = {},
-        fallback = { display_global_mode = "fallback" },
+        fallback = { display_global_mode = 'fallback' },
       },
       lsp_clients = {},
-    }, { conform = "C", lsp = "L", file = "F", filetype = "lua" }, { unavailable = "!" })
+    }, { conform = 'C', lsp = 'L', file = 'F', filetype = 'lua' }, { unavailable = '!' })
 
     assert.are.same({
-      id = "conform_empty",
-      text = "! C Conform: no formatters available",
+      id = 'conform_empty',
+      text = '! C Conform: no formatters available',
       toggleable = false,
-      kind = "info",
-      status = "unavailable",
-      status_icon = "!",
-      source_icon = "C",
-    }, find_row(built, "conform_empty"))
+      kind = 'info',
+      status = 'unavailable',
+      status_icon = '!',
+      source_icon = 'C',
+    }, find_row(built, 'conform_empty'))
 
     assert.are.same({
-      id = "lsp_empty",
-      text = "! L LSP: no attached clients",
+      id = 'lsp_empty',
+      text = '! L LSP: no attached clients',
       toggleable = false,
-      kind = "info",
-      status = "unavailable",
-      status_icon = "!",
-      source_icon = "L",
-    }, find_row(built, "lsp_empty"))
+      kind = 'info',
+      status = 'unavailable',
+      status_icon = '!',
+      source_icon = 'L',
+    }, find_row(built, 'lsp_empty'))
   end)
 
-  it("stores shared section metadata separately from section text", function()
-    local rows = require("cosmic-ui.formatters.ui.rows")
+  it('stores shared section metadata separately from section text', function()
+    local rows = require('cosmic-ui.formatters.ui.rows')
     local built = rows.build_rows({
       conform = {
         available = true,
         reason = nil,
         formatters = {
-          { name = "stylua", enabled = true },
+          { name = 'stylua', enabled = true },
         },
         fallback = {
-          display_global_mode = "never",
-          display_specific_mode = "fallback",
+          display_global_mode = 'never',
+          display_specific_mode = 'fallback',
         },
       },
       lsp_clients = {
-        { name = "lua_ls", available = true, enabled = true },
+        { name = 'lua_ls', available = true, enabled = true },
       },
-    }, { conform = "C", lsp = "L", file = "F", filetype = "lua" }, {
-      enabled = "+",
-      disabled = "-",
-      unavailable = "!",
+    }, { conform = 'C', lsp = 'L', file = 'F', filetype = 'lua' }, {
+      enabled = '+',
+      disabled = '-',
+      unavailable = '!',
     })
 
     assert.are.same({
-      id = "section_conform",
-      text = "Conform",
+      id = 'section_conform',
+      text = 'Conform',
       toggleable = false,
-      kind = "section",
-    }, find_row(built, "section_conform"))
+      kind = 'section',
+    }, find_row(built, 'section_conform'))
 
     assert.are.same({
-      id = "section_lsp",
-      text = "LSP",
-      subtitle = "fallback",
+      id = 'section_lsp',
+      text = 'LSP',
+      subtitle = 'fallback',
       toggleable = false,
-      kind = "section",
-    }, find_row(built, "section_lsp"))
+      kind = 'section',
+    }, find_row(built, 'section_lsp'))
   end)
 
-  it("renders section subtitles and shared footer highlights through the formatter panel", function()
-    local constants = require("cosmic-ui.formatters.constants")
-    local highlights = require("cosmic-ui.formatters.ui.highlights")
-    local input = require("cosmic-ui.formatters.ui.input")
-    local render = require("cosmic-ui.formatters.ui.render")
+  it('renders section subtitles and shared footer highlights through the formatter panel', function()
+    local constants = require('cosmic-ui.formatters.constants')
+    local highlights = require('cosmic-ui.formatters.ui.highlights')
+    local input = require('cosmic-ui.formatters.ui.input')
+    local render = require('cosmic-ui.formatters.ui.render')
 
     local buf = vim.api.nvim_create_buf(false, true)
     local ui = {
       buf = buf,
       win = vim.api.nvim_get_current_win(),
-      scope = "buffer",
+      scope = 'buffer',
       target_bufnr = 0,
       selected = nil,
       rows = {},
@@ -145,7 +145,7 @@ describe("cosmic-ui.formatters.ui.rows", function()
     local deps = {
       logger = {},
       close_fn = function()
-        error("render should not close the panel")
+        error('render should not close the panel')
       end,
       ui_state = {},
       constants = constants,
@@ -156,31 +156,31 @@ describe("cosmic-ui.formatters.ui.rows", function()
         end,
         make_icons = function()
           return {
-            file = "F",
-            filetype = "lua",
+            file = 'F',
+            filetype = 'lua',
           }
         end,
         build_rows = function()
           return {
             {
-              id = "section_lsp",
-              kind = "section",
-              text = "LSP",
-              subtitle = "fallback",
+              id = 'section_lsp',
+              kind = 'section',
+              text = 'LSP',
+              subtitle = 'fallback',
               toggleable = false,
             },
             {
-              id = "lsp_lua_ls",
-              kind = "item",
-              text = "+ L lua_ls",
+              id = 'lsp_lua_ls',
+              kind = 'item',
+              text = '+ L lua_ls',
               toggleable = true,
-              status = "enabled",
-              status_icon = "+",
-              source_icon = "L",
+              status = 'enabled',
+              status_icon = '+',
+              source_icon = 'L',
               action = {
-                kind = "item",
-                source = "lsp",
-                name = "lua_ls",
+                kind = 'item',
+                source = 'lsp',
+                name = 'lua_ls',
               },
             },
           }
@@ -207,27 +207,30 @@ describe("cosmic-ui.formatters.ui.rows", function()
     local has_footer_text_hl = false
     local has_subtitle_hl = false
 
-    assert.are.equal(" LSP  fallback", rstrip(lines[ui.rows[1].lnum]))
-    assert.are.equal(" Tab:toggle+next  s:scope  r:reset  a:toggle all  f:format  q:close", rstrip(lines[ui.footer_lnum]))
+    assert.are.equal(' LSP  fallback', rstrip(lines[ui.rows[1].lnum]))
+    assert.are.equal(
+      ' Tab:toggle+next  s:scope  r:reset  a:toggle all  f:format  q:close',
+      rstrip(lines[ui.footer_lnum])
+    )
     assert.are.same({
-      highlight = "CosmicUiPanelHintKey",
+      highlight = 'CosmicUiPanelHintKey',
       start_col = 1,
       end_col = 4,
     }, ui.footer_spans[1])
     assert.are.same({
-      highlight = "CosmicUiPanelHintText",
+      highlight = 'CosmicUiPanelHintText',
       start_col = 5,
       end_col = 16,
     }, ui.footer_spans[2])
 
     for _, mark in ipairs(extmarks) do
-      if mark.lnum == ui.footer_lnum - 1 and mark.hl_group == "CosmicUiPanelHintKey" then
+      if mark.lnum == ui.footer_lnum - 1 and mark.hl_group == 'CosmicUiPanelHintKey' then
         has_footer_key_hl = true
       end
-      if mark.lnum == ui.footer_lnum - 1 and mark.hl_group == "CosmicUiPanelHintText" then
+      if mark.lnum == ui.footer_lnum - 1 and mark.hl_group == 'CosmicUiPanelHintText' then
         has_footer_text_hl = true
       end
-      if mark.lnum == ui.rows[1].lnum - 1 and mark.hl_group == "CosmicUiFmtSubtitle" then
+      if mark.lnum == ui.rows[1].lnum - 1 and mark.hl_group == 'CosmicUiFmtSubtitle' then
         has_subtitle_hl = true
       end
     end

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,9 +1,9 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
-for _, path in ipairs(vim.fn.globpath(vim.fn.stdpath("data") .. "/site/pack/*/start", "plenary.nvim", false, true)) do
+for _, path in ipairs(vim.fn.globpath(vim.fn.stdpath('data') .. '/site/pack/*/start', 'plenary.nvim', false, true)) do
   vim.opt.runtimepath:append(path)
 end
-for _, path in ipairs(vim.fn.globpath(vim.fn.stdpath("data") .. "/lazy", "plenary.nvim", false, true)) do
+for _, path in ipairs(vim.fn.globpath(vim.fn.stdpath('data') .. '/lazy', 'plenary.nvim', false, true)) do
   vim.opt.runtimepath:append(path)
 end
 vim.opt.swapfile = false
-vim.opt.shadafile = "NONE"
+vim.opt.shadafile = 'NONE'

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,9 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+for _, path in ipairs(vim.fn.globpath(vim.fn.stdpath("data") .. "/site/pack/*/start", "plenary.nvim", false, true)) do
+  vim.opt.runtimepath:append(path)
+end
+for _, path in ipairs(vim.fn.globpath(vim.fn.stdpath("data") .. "/lazy", "plenary.nvim", false, true)) do
+  vim.opt.runtimepath:append(path)
+end
+vim.opt.swapfile = false
+vim.opt.shadafile = "NONE"

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -467,6 +467,39 @@ describe('cosmic-ui.rename.ui', function()
     assert.are.same({ 1, 6 }, vim.api.nvim_win_get_cursor(origin_win))
   end)
 
+  it('closes on focus loss without restoring origin focus', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+    local origin_win = vim.api.nvim_get_current_win()
+
+    vim.cmd('split')
+    local other_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_set_current_win(origin_win)
+
+    ui.open({
+      default_value = 'next_name',
+      on_submit = function()
+        error('rename should not submit on focus loss')
+      end,
+    })
+
+    vim.api.nvim_set_current_win(other_win)
+    vim.wait(1000, function()
+      return vim.api.nvim_get_current_win() == other_win
+    end)
+    vim.wait(300, function()
+      return false
+    end)
+
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      local config = vim.api.nvim_win_get_config(win)
+      assert.is_false(config.relative ~= '')
+    end
+
+    assert.are.equal(other_win, vim.api.nvim_get_current_win())
+  end)
+
   it('keeps the cursor on the renamed symbol after submitting a shorter name', function()
     stub_rename_context('very_long_name')
     local ui = require('cosmic-ui.rename.ui')

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -75,6 +75,32 @@ describe('cosmic-ui.rename.ui', function()
     end
   end
 
+  local function load_rename_ui_with_panel_stub(panel_stub)
+    local original_panel = package.loaded['cosmic-ui.ui.panel']
+    local original_ui = package.loaded['cosmic-ui.rename.ui']
+
+    package.loaded['cosmic-ui.ui.panel'] = panel_stub
+    package.loaded['cosmic-ui.rename.ui'] = nil
+
+    local ok, loaded_ui = pcall(require, 'cosmic-ui.rename.ui')
+
+    package.loaded['cosmic-ui.rename.ui'] = nil
+    if original_ui ~= nil then
+      package.loaded['cosmic-ui.rename.ui'] = original_ui
+    end
+
+    package.loaded['cosmic-ui.ui.panel'] = nil
+    if original_panel ~= nil then
+      package.loaded['cosmic-ui.ui.panel'] = original_panel
+    end
+
+    if not ok then
+      error(loaded_ui)
+    end
+
+    return loaded_ui
+  end
+
   local function stub_workspace_edit_rename(old_name)
     original_lsp_rename = vim.lsp.buf.rename
     local rename_calls = {}
@@ -292,6 +318,38 @@ describe('cosmic-ui.rename.ui', function()
     assert.are.same({ '> next_name' }, lines)
     assert.is_false(vim.tbl_contains(lines, ' Current: current_name '))
     assert.is_false(vim.tbl_contains(lines, ' Enter:rename  Esc:cancel '))
+  end)
+
+  it('keeps compact rename rendering independent from panel helpers', function()
+    stub_rename_context('current_name')
+
+    local actual_panel = require('cosmic-ui.ui.panel')
+    local prepare_calls = 0
+    local footer_calls = 0
+    local ui = load_rename_ui_with_panel_stub({
+      prepare = function(...)
+        prepare_calls = prepare_calls + 1
+        return actual_panel.prepare(...)
+      end,
+      render_footer = function(...)
+        footer_calls = footer_calls + 1
+        return actual_panel.render_footer(...)
+      end,
+    })
+
+    ui.open({
+      default_value = 'current_name',
+    })
+
+    press('<CR>')
+    vim.wait(1000, function()
+      local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
+      return #lines == 1 and lines[1] == '> current_name'
+    end)
+
+    assert.are.equal(0, prepare_calls)
+    assert.are.equal(0, footer_calls)
+    assert.are.same({ '> current_name' }, vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false))
   end)
 
   it('keeps the cursor on the prompt line after a rejected unchanged submit', function()

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -172,6 +172,22 @@ describe('cosmic-ui.rename.ui', function()
     assert.are.same(before, after)
   end)
 
+  it('renders the default compact rename buffer as a single prompt line', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+
+    ui.open({
+      default_value = 'next_name',
+    })
+
+    local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
+
+    assert.are.same({ '> next_name' }, lines)
+    assert.is_false(vim.tbl_contains(lines, ' Current: current_name '))
+    assert.is_false(vim.tbl_contains(lines, ' Enter:rename  Esc:cancel '))
+  end)
+
   it('preserves explicit window width and height overrides after render', function()
     stub_rename_context('current_name')
 

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -12,6 +12,13 @@ describe("cosmic-ui.rename.model", function()
 
     assert.are.same({ ok = false, reason = "unchanged" }, result)
   end)
+
+  it("extracts the submitted value from the prompt line", function()
+    local model = require("cosmic-ui.rename.model")
+
+    assert.are.equal("next_name", model.extract_value("> ", "> next_name"))
+    assert.are.equal("raw_name", model.extract_value("> ", "raw_name"))
+  end)
 end)
 
 describe("cosmic-ui.rename.ui", function()
@@ -96,6 +103,47 @@ describe("cosmic-ui.rename.ui", function()
       name = "next_name",
       win = origin_win,
     }, submitted)
+  end)
+
+  it("allows editing the prompt line before submit", function()
+    stub_rename_context("current_name")
+
+    local ui = require("cosmic-ui.rename.ui")
+    local submitted
+
+    ui.open({
+      default_value = "draft",
+      on_submit = function(new_name)
+        submitted = new_name
+      end,
+    })
+
+    vim.cmd("normal! A2")
+    press("<CR>")
+    vim.wait(1000, function()
+      return submitted ~= nil
+    end)
+
+    assert.are.equal("draft2", submitted)
+  end)
+
+  it("preserves explicit window width and height overrides after render", function()
+    stub_rename_context("current_name")
+
+    local ui = require("cosmic-ui.rename.ui")
+
+    ui.open({
+      default_value = "next_name",
+      window = {
+        width = 52,
+        height = 7,
+      },
+    })
+
+    local cfg = vim.api.nvim_win_get_config(vim.api.nvim_get_current_win())
+
+    assert.are.equal(52, cfg.width)
+    assert.are.equal(7, cfg.height)
   end)
 
   it("rejects empty submit from the panel without dispatching rename", function()

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -25,6 +25,22 @@ describe('cosmic-ui.rename.ui', function()
   local original_get_clients
   local original_expand
 
+  local function collect_highlights(bufnr, ns)
+    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+    local collected = {}
+
+    for _, mark in ipairs(marks) do
+      table.insert(collected, {
+        lnum = mark[2],
+        col = mark[3],
+        end_col = mark[4].end_col,
+        hl_group = mark[4].hl_group,
+      })
+    end
+
+    return collected
+  end
+
   local function stub_rename_context(current_name)
     original_get_clients = vim.lsp.get_clients
     original_expand = vim.fn.expand
@@ -144,6 +160,61 @@ describe('cosmic-ui.rename.ui', function()
 
     assert.are.equal(52, cfg.width)
     assert.are.equal(7, cfg.height)
+  end)
+
+  it('highlights footer helpers from the first character', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+    local ns = vim.api.nvim_get_namespaces()['cosmic-ui-rename-panel']
+
+    ui.open({
+      default_value = 'next_name',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local marks = collect_highlights(buf, ns)
+    local footer_marks = {}
+
+    assert.are.equal(' Enter:rename  Esc:cancel ', lines[#lines])
+
+    for _, mark in ipairs(marks) do
+      if mark.lnum == #lines - 1 then
+        table.insert(footer_marks, mark)
+      end
+    end
+
+    table.sort(footer_marks, function(left, right)
+      return left.col < right.col
+    end)
+
+    assert.are.same({
+      {
+        lnum = #lines - 1,
+        col = 1,
+        end_col = 6,
+        hl_group = 'CosmicUiPanelHintKey',
+      },
+      {
+        lnum = #lines - 1,
+        col = 7,
+        end_col = 13,
+        hl_group = 'CosmicUiPanelHintText',
+      },
+      {
+        lnum = #lines - 1,
+        col = 15,
+        end_col = 18,
+        hl_group = 'CosmicUiPanelHintKey',
+      },
+      {
+        lnum = #lines - 1,
+        col = 19,
+        end_col = 25,
+        hl_group = 'CosmicUiPanelHintText',
+      },
+    }, footer_marks)
   end)
 
   it('rejects empty submit from the panel without dispatching rename', function()

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -25,22 +25,6 @@ describe('cosmic-ui.rename.ui', function()
   local original_get_clients
   local original_expand
 
-  local function collect_highlights(bufnr, ns)
-    local marks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
-    local collected = {}
-
-    for _, mark in ipairs(marks) do
-      table.insert(collected, {
-        lnum = mark[2],
-        col = mark[3],
-        end_col = mark[4].end_col,
-        hl_group = mark[4].hl_group,
-      })
-    end
-
-    return collected
-  end
-
   local function stub_rename_context(current_name)
     original_get_clients = vim.lsp.get_clients
     original_expand = vim.fn.expand
@@ -135,8 +119,9 @@ describe('cosmic-ui.rename.ui', function()
     })
 
     local buf = vim.api.nvim_get_current_buf()
+    assert.are.same({ '> draft' }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
     vim.bo[buf].modifiable = true
-    vim.api.nvim_buf_set_text(buf, 2, 7, 2, 7, { '2' })
+    vim.api.nvim_buf_set_text(buf, 0, 7, 0, 7, { '2' })
     vim.bo[buf].modifiable = false
 
     press('<CR>')
@@ -172,7 +157,7 @@ describe('cosmic-ui.rename.ui', function()
     assert.are.same(before, after)
   end)
 
-  it('renders the default compact rename buffer as a single prompt line', function()
+  it('renders the compact rename buffer as a single editable prompt line', function()
     stub_rename_context('current_name')
 
     local ui = require('cosmic-ui.rename.ui')
@@ -186,6 +171,34 @@ describe('cosmic-ui.rename.ui', function()
     assert.are.same({ '> next_name' }, lines)
     assert.is_false(vim.tbl_contains(lines, ' Current: current_name '))
     assert.is_false(vim.tbl_contains(lines, ' Enter:rename  Esc:cancel '))
+  end)
+
+  it('keeps the cursor on the prompt line after a rejected unchanged submit', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+
+    ui.open({
+      default_value = 'current_name',
+    })
+
+    local win = vim.api.nvim_get_current_win()
+    local prompt_len = #'> '
+
+    vim.api.nvim_win_set_cursor(win, { 1, prompt_len + 2 })
+
+    press('<CR>')
+    vim.wait(1000, function()
+      local cursor = vim.api.nvim_win_get_cursor(win)
+      return cursor[1] == 1 and cursor[2] >= prompt_len
+    end)
+
+    local cursor = vim.api.nvim_win_get_cursor(win)
+    local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
+
+    assert.are.same({ '> current_name' }, lines)
+    assert.are.equal(1, cursor[1])
+    assert.is_true(cursor[2] >= prompt_len)
   end)
 
   it('preserves explicit window width and height overrides after render', function()
@@ -207,62 +220,7 @@ describe('cosmic-ui.rename.ui', function()
     assert.are.equal(7, cfg.height)
   end)
 
-  it('highlights footer helpers from the first character', function()
-    stub_rename_context('current_name')
-
-    local ui = require('cosmic-ui.rename.ui')
-    local ns = vim.api.nvim_get_namespaces()['cosmic-ui-rename-panel']
-
-    ui.open({
-      default_value = 'next_name',
-    })
-
-    local buf = vim.api.nvim_get_current_buf()
-    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    local marks = collect_highlights(buf, ns)
-    local footer_marks = {}
-
-    assert.are.equal(' Enter:rename  Esc:cancel ', lines[#lines])
-
-    for _, mark in ipairs(marks) do
-      if mark.lnum == #lines - 1 then
-        table.insert(footer_marks, mark)
-      end
-    end
-
-    table.sort(footer_marks, function(left, right)
-      return left.col < right.col
-    end)
-
-    assert.are.same({
-      {
-        lnum = #lines - 1,
-        col = 1,
-        end_col = 6,
-        hl_group = 'CosmicUiPanelHintKey',
-      },
-      {
-        lnum = #lines - 1,
-        col = 7,
-        end_col = 13,
-        hl_group = 'CosmicUiPanelHintText',
-      },
-      {
-        lnum = #lines - 1,
-        col = 15,
-        end_col = 18,
-        hl_group = 'CosmicUiPanelHintKey',
-      },
-      {
-        lnum = #lines - 1,
-        col = 19,
-        end_col = 25,
-        hl_group = 'CosmicUiPanelHintText',
-      },
-    }, footer_marks)
-  end)
-
-  it('rejects empty submit from the panel without dispatching rename', function()
+  it('rejects empty submit without adding validation rows', function()
     stub_rename_context('current_name')
 
     local ui = require('cosmic-ui.rename.ui')
@@ -278,20 +236,15 @@ describe('cosmic-ui.rename.ui', function()
     press('<CR>')
     vim.wait(1000, function()
       local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
-      return vim.tbl_contains(lines, ' Name cannot be empty ')
+      return #lines == 1 and lines[1] == '> '
     end)
 
     assert.are.equal(0, submissions)
     assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= '')
-    assert.is_true(
-      vim.tbl_contains(
-        vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false),
-        ' Name cannot be empty '
-      )
-    )
+    assert.are.same({ '> ' }, vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false))
   end)
 
-  it('rejects unchanged submit from the panel without dispatching rename', function()
+  it('rejects unchanged submit without rendering helper rows', function()
     stub_rename_context('current_name')
 
     local ui = require('cosmic-ui.rename.ui')
@@ -307,14 +260,12 @@ describe('cosmic-ui.rename.ui', function()
     press('<CR>')
     vim.wait(1000, function()
       local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
-      return vim.tbl_contains(lines, ' Name is unchanged ')
+      return #lines == 1 and lines[1] == '> current_name'
     end)
 
     assert.are.equal(0, submissions)
     assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= '')
-    assert.is_true(
-      vim.tbl_contains(vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false), ' Name is unchanged ')
-    )
+    assert.are.same({ '> current_name' }, vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false))
   end)
 
   it('restores focus to the origin window on cancel', function()

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -1,27 +1,27 @@
-describe("cosmic-ui.rename.model", function()
-  it("rejects empty submissions without dispatching rename", function()
-    local model = require("cosmic-ui.rename.model")
-    local result = model.normalize_submission("> ", "> ", "> ")
+describe('cosmic-ui.rename.model', function()
+  it('rejects empty submissions without dispatching rename', function()
+    local model = require('cosmic-ui.rename.model')
+    local result = model.normalize_submission('> ', '> ', '> ')
 
-    assert.are.same({ ok = false, reason = "empty" }, result)
+    assert.are.same({ ok = false, reason = 'empty' }, result)
   end)
 
-  it("rejects unchanged submissions", function()
-    local model = require("cosmic-ui.rename.model")
-    local result = model.normalize_submission("> ", "> current_name", "current_name")
+  it('rejects unchanged submissions', function()
+    local model = require('cosmic-ui.rename.model')
+    local result = model.normalize_submission('> ', '> current_name', 'current_name')
 
-    assert.are.same({ ok = false, reason = "unchanged" }, result)
+    assert.are.same({ ok = false, reason = 'unchanged' }, result)
   end)
 
-  it("extracts the submitted value from the prompt line", function()
-    local model = require("cosmic-ui.rename.model")
+  it('extracts the submitted value from the prompt line', function()
+    local model = require('cosmic-ui.rename.model')
 
-    assert.are.equal("next_name", model.extract_value("> ", "> next_name"))
-    assert.are.equal("raw_name", model.extract_value("> ", "raw_name"))
+    assert.are.equal('next_name', model.extract_value('> ', '> next_name'))
+    assert.are.equal('raw_name', model.extract_value('> ', 'raw_name'))
   end)
 end)
 
-describe("cosmic-ui.rename.ui", function()
+describe('cosmic-ui.rename.ui', function()
   local original_get_clients
   local original_expand
 
@@ -31,12 +31,12 @@ describe("cosmic-ui.rename.ui", function()
 
     vim.lsp.get_clients = function()
       return {
-        { id = 1, name = "lua_ls" },
+        { id = 1, name = 'lua_ls' },
       }
     end
 
     vim.fn.expand = function(expr)
-      if expr == "<cword>" then
+      if expr == '<cword>' then
         return current_name
       end
 
@@ -57,7 +57,7 @@ describe("cosmic-ui.rename.ui", function()
   end
 
   local function press(keys)
-    vim.api.nvim_feedkeys(vim.keycode(keys), "xt", false)
+    vim.api.nvim_feedkeys(vim.keycode(keys), 'xt', false)
   end
 
   after_each(function()
@@ -65,26 +65,26 @@ describe("cosmic-ui.rename.ui", function()
 
     for _, win in ipairs(vim.api.nvim_list_wins()) do
       local config = vim.api.nvim_win_get_config(win)
-      if config.relative ~= "" then
+      if config.relative ~= '' then
         pcall(vim.api.nvim_win_close, win, true)
       end
     end
 
-    vim.cmd("silent! only")
+    vim.cmd('silent! only')
   end)
 
-  it("restores focus to the origin window on submit", function()
-    stub_rename_context("current_name")
+  it('restores focus to the origin window on submit', function()
+    stub_rename_context('current_name')
 
-    local ui = require("cosmic-ui.rename.ui")
+    local ui = require('cosmic-ui.rename.ui')
     local origin_win = vim.api.nvim_get_current_win()
     local submitted
 
-    vim.cmd("split")
+    vim.cmd('split')
     vim.api.nvim_set_current_win(origin_win)
 
     ui.open({
-      default_value = "next_name",
+      default_value = 'next_name',
       on_submit = function(new_name)
         submitted = {
           name = new_name,
@@ -93,47 +93,47 @@ describe("cosmic-ui.rename.ui", function()
       end,
     })
 
-    press("<CR>")
+    press('<CR>')
     vim.wait(1000, function()
       return submitted ~= nil
     end)
 
     assert.are.equal(origin_win, vim.api.nvim_get_current_win())
     assert.are.same({
-      name = "next_name",
+      name = 'next_name',
       win = origin_win,
     }, submitted)
   end)
 
-  it("allows editing the prompt line before submit", function()
-    stub_rename_context("current_name")
+  it('allows editing the prompt line before submit', function()
+    stub_rename_context('current_name')
 
-    local ui = require("cosmic-ui.rename.ui")
+    local ui = require('cosmic-ui.rename.ui')
     local submitted
 
     ui.open({
-      default_value = "draft",
+      default_value = 'draft',
       on_submit = function(new_name)
         submitted = new_name
       end,
     })
 
-    vim.cmd("normal! A2")
-    press("<CR>")
+    vim.cmd('normal! A2')
+    press('<CR>')
     vim.wait(1000, function()
       return submitted ~= nil
     end)
 
-    assert.are.equal("draft2", submitted)
+    assert.are.equal('draft2', submitted)
   end)
 
-  it("preserves explicit window width and height overrides after render", function()
-    stub_rename_context("current_name")
+  it('preserves explicit window width and height overrides after render', function()
+    stub_rename_context('current_name')
 
-    local ui = require("cosmic-ui.rename.ui")
+    local ui = require('cosmic-ui.rename.ui')
 
     ui.open({
-      default_value = "next_name",
+      default_value = 'next_name',
       window = {
         width = 52,
         height = 7,
@@ -146,77 +146,78 @@ describe("cosmic-ui.rename.ui", function()
     assert.are.equal(7, cfg.height)
   end)
 
-  it("rejects empty submit from the panel without dispatching rename", function()
-    stub_rename_context("current_name")
+  it('rejects empty submit from the panel without dispatching rename', function()
+    stub_rename_context('current_name')
 
-    local ui = require("cosmic-ui.rename.ui")
+    local ui = require('cosmic-ui.rename.ui')
     local submissions = 0
 
     ui.open({
-      default_value = "",
+      default_value = '',
       on_submit = function()
         submissions = submissions + 1
       end,
     })
 
-    press("<CR>")
+    press('<CR>')
     vim.wait(1000, function()
       local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
-      return vim.tbl_contains(lines, " Name cannot be empty ")
+      return vim.tbl_contains(lines, ' Name cannot be empty ')
     end)
 
     assert.are.equal(0, submissions)
-    assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= "")
-    assert.is_true(vim.tbl_contains(
-      vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false),
-      " Name cannot be empty "
-    ))
+    assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= '')
+    assert.is_true(
+      vim.tbl_contains(
+        vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false),
+        ' Name cannot be empty '
+      )
+    )
   end)
 
-  it("rejects unchanged submit from the panel without dispatching rename", function()
-    stub_rename_context("current_name")
+  it('rejects unchanged submit from the panel without dispatching rename', function()
+    stub_rename_context('current_name')
 
-    local ui = require("cosmic-ui.rename.ui")
+    local ui = require('cosmic-ui.rename.ui')
     local submissions = 0
 
     ui.open({
-      default_value = "current_name",
+      default_value = 'current_name',
       on_submit = function()
         submissions = submissions + 1
       end,
     })
 
-    press("<CR>")
+    press('<CR>')
     vim.wait(1000, function()
       local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
-      return vim.tbl_contains(lines, " Name is unchanged ")
+      return vim.tbl_contains(lines, ' Name is unchanged ')
     end)
 
     assert.are.equal(0, submissions)
-    assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= "")
-    assert.is_true(vim.tbl_contains(
-      vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false),
-      " Name is unchanged "
-    ))
+    assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= '')
+    assert.is_true(
+      vim.tbl_contains(vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false), ' Name is unchanged ')
+    )
   end)
 
-  it("restores focus to the origin window on cancel", function()
-    stub_rename_context("current_name")
+  it('restores focus to the origin window on cancel', function()
+    stub_rename_context('current_name')
 
-    local ui = require("cosmic-ui.rename.ui")
+    local ui = require('cosmic-ui.rename.ui')
     local origin_win = vim.api.nvim_get_current_win()
 
-    vim.cmd("split")
+    vim.cmd('split')
     vim.api.nvim_set_current_win(origin_win)
 
     ui.open({
-      default_value = "next_name",
+      default_value = 'next_name',
       on_submit = function()
-        error("rename should not submit on cancel")
+        error('rename should not submit on cancel')
       end,
     })
 
-    press("<Esc>")
+    press('<Esc>')
     vim.wait(1000, function()
       return vim.api.nvim_get_current_win() == origin_win
     end)

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -24,6 +24,7 @@ end)
 describe('cosmic-ui.rename.ui', function()
   local original_get_clients
   local original_expand
+  local original_lsp_rename
 
   local function stub_rename_context(current_name)
     original_get_clients = vim.lsp.get_clients
@@ -54,10 +55,55 @@ describe('cosmic-ui.rename.ui', function()
       vim.fn.expand = original_expand
       original_expand = nil
     end
+
+    if original_lsp_rename then
+      vim.lsp.buf.rename = original_lsp_rename
+      original_lsp_rename = nil
+    end
   end
 
   local function press(keys)
     vim.api.nvim_feedkeys(vim.keycode(keys), 'xt', false)
+  end
+
+  local function prepare_named_buffer(lines, cursor)
+    vim.cmd('enew!')
+    vim.api.nvim_buf_set_name(0, vim.fn.tempname() .. '.js')
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+    if cursor then
+      vim.api.nvim_win_set_cursor(0, cursor)
+    end
+  end
+
+  local function stub_workspace_edit_rename(old_name)
+    original_lsp_rename = vim.lsp.buf.rename
+    local rename_calls = {}
+
+    vim.lsp.buf.rename = function(new_name)
+      table.insert(rename_calls, new_name)
+
+      local buf = vim.api.nvim_get_current_buf()
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      local row = cursor[1] - 1
+      local line = vim.api.nvim_get_current_line()
+      local start_col, end_col = line:find(old_name, 1, true)
+
+      vim.lsp.util.apply_workspace_edit({
+        changes = {
+          [vim.uri_from_bufnr(buf)] = {
+            {
+              range = {
+                start = { line = row, character = start_col - 1 },
+                ['end'] = { line = row, character = end_col },
+              },
+              newText = new_name,
+            },
+          },
+        },
+      }, 'utf-16')
+    end
+
+    return rename_calls
   end
 
   after_each(function()
@@ -153,6 +199,52 @@ describe('cosmic-ui.rename.ui', function()
     end)
 
     assert.is_true(vim.bo[buf].modifiable)
+  end)
+
+  it('stops insert mode before closing on escape', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+    local original_cmd = vim.cmd
+    local original_mode = vim.fn.mode
+    local seen = {}
+
+    vim.fn.mode = function()
+      return 'i'
+    end
+
+    vim.cmd = function(command)
+      if command == 'startinsert!' then
+        return
+      end
+
+      if command == 'stopinsert' then
+        table.insert(seen, command)
+        return
+      end
+
+      return original_cmd(command)
+    end
+
+    local ok, err = pcall(function()
+      ui.open({
+        default_value = 'next_name',
+      })
+
+      press('<Esc>')
+      vim.wait(1000, function()
+        return #seen > 0
+      end)
+    end)
+
+    vim.cmd = original_cmd
+    vim.fn.mode = original_mode
+
+    if not ok then
+      error(err)
+    end
+
+    assert.are.same({ 'stopinsert' }, seen)
   end)
 
   it('clamps the cursor to the prompt prefix in compact mode', function()
@@ -319,5 +411,120 @@ describe('cosmic-ui.rename.ui', function()
     end)
 
     assert.are.equal(origin_win, vim.api.nvim_get_current_win())
+  end)
+
+  it('restores the origin cursor position on cancel', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+    local origin_win = vim.api.nvim_get_current_win()
+
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'alpha beta', 'gamma' })
+    vim.api.nvim_win_set_cursor(origin_win, { 1, 7 })
+
+    ui.open({
+      default_value = 'next_name',
+      on_submit = function()
+        error('rename should not submit on cancel')
+      end,
+    })
+
+    press('<Esc>')
+    vim.wait(1000, function()
+      return vim.api.nvim_get_current_win() == origin_win
+        and vim.deep_equal(vim.api.nvim_win_get_cursor(origin_win), { 1, 7 })
+    end)
+
+    assert.are.equal(origin_win, vim.api.nvim_get_current_win())
+    assert.are.same({ 1, 7 }, vim.api.nvim_win_get_cursor(origin_win))
+  end)
+
+  it('restores the origin cursor position on cancel when starting on the first letter of a word', function()
+    stub_rename_context('beta')
+
+    local ui = require('cosmic-ui.rename.ui')
+    local origin_win = vim.api.nvim_get_current_win()
+
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'alpha beta', 'gamma' })
+    vim.api.nvim_win_set_cursor(origin_win, { 1, 6 })
+
+    ui.open({
+      default_value = 'beta',
+      on_submit = function()
+        error('rename should not submit on cancel')
+      end,
+    })
+
+    press('<Esc>')
+    vim.wait(1000, function()
+      return vim.api.nvim_get_current_win() == origin_win
+    end)
+    vim.wait(300, function()
+      return false
+    end)
+
+    assert.are.equal(origin_win, vim.api.nvim_get_current_win())
+    assert.are.same({ 1, 6 }, vim.api.nvim_win_get_cursor(origin_win))
+  end)
+
+  it('keeps the cursor on the renamed symbol after submitting a shorter name', function()
+    stub_rename_context('very_long_name')
+    local ui = require('cosmic-ui.rename.ui')
+    local origin_win = vim.api.nvim_get_current_win()
+    local rename_calls = stub_workspace_edit_rename('very_long_name')
+
+    prepare_named_buffer({ 'const very_long_name = 1;' }, { 1, 16 })
+
+    ui.open({
+      default_value = 'very_long_name',
+    })
+
+    local prompt_buf = vim.api.nvim_get_current_buf()
+    vim.bo[prompt_buf].modifiable = true
+    vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { '> short' })
+    vim.bo[prompt_buf].modifiable = false
+
+    press('<CR>')
+    vim.wait(1000, function()
+      return vim.api.nvim_get_current_win() == origin_win and vim.api.nvim_get_current_line() == 'const short = 1;'
+    end)
+    vim.wait(300, function()
+      return false
+    end)
+
+    assert.are.same({ 'short' }, rename_calls)
+    assert.are.equal(origin_win, vim.api.nvim_get_current_win())
+    assert.are.same({ 1, 10 }, vim.api.nvim_win_get_cursor(origin_win))
+  end)
+
+  it('keeps the cursor at the trigger position after submitting a longer name', function()
+    stub_rename_context('mid')
+    local ui = require('cosmic-ui.rename.ui')
+    local origin_win = vim.api.nvim_get_current_win()
+    local rename_calls = stub_workspace_edit_rename('mid')
+
+    prepare_named_buffer({ 'const mid = 1;' }, { 1, 8 })
+
+    ui.open({
+      default_value = 'mid',
+    })
+
+    local prompt_buf = vim.api.nvim_get_current_buf()
+    vim.bo[prompt_buf].modifiable = true
+    vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, { '> much_longer_name' })
+    vim.bo[prompt_buf].modifiable = false
+
+    press('<CR>')
+    vim.wait(1000, function()
+      return vim.api.nvim_get_current_win() == origin_win
+        and vim.api.nvim_get_current_line() == 'const much_longer_name = 1;'
+    end)
+    vim.wait(300, function()
+      return false
+    end)
+
+    assert.are.same({ 'much_longer_name' }, rename_calls)
+    assert.are.equal(origin_win, vim.api.nvim_get_current_win())
+    assert.are.same({ 1, 8 }, vim.api.nvim_win_get_cursor(origin_win))
   end)
 end)

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -132,7 +132,7 @@ describe('cosmic-ui.rename.ui', function()
     assert.are.equal('draft2', submitted)
   end)
 
-  it('locks the panel outside insert mode so helper lines cannot be edited', function()
+  it('keeps the compact rename buffer modifiable for prompt editing', function()
     stub_rename_context('current_name')
 
     local ui = require('cosmic-ui.rename.ui')
@@ -144,17 +144,46 @@ describe('cosmic-ui.rename.ui', function()
     local buf = vim.api.nvim_get_current_buf()
     local before = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
 
+    assert.are.same({ '> next_name' }, before)
+    assert.is_true(vim.bo[buf].modifiable)
+
     vim.cmd('stopinsert')
     vim.wait(1000, function()
       return vim.fn.mode() == 'n'
     end)
 
-    local ok = pcall(vim.cmd, 'normal! G0rx')
-    local after = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    assert.is_true(vim.bo[buf].modifiable)
+  end)
 
-    assert.is_false(vim.bo[buf].modifiable)
-    assert.is_false(ok)
-    assert.are.same(before, after)
+  it('clamps the cursor to the prompt prefix in compact mode', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+
+    ui.open({
+      default_value = 'next_name',
+    })
+
+    local win = vim.api.nvim_get_current_win()
+    local buf = vim.api.nvim_get_current_buf()
+    local prompt_len = #'> '
+
+    vim.cmd('stopinsert')
+    vim.wait(1000, function()
+      return vim.fn.mode() == 'n'
+    end)
+
+    vim.api.nvim_win_set_cursor(win, { 1, 0 })
+    vim.api.nvim_exec_autocmds('CursorMoved', { buffer = buf })
+    vim.wait(1000, function()
+      local cursor = vim.api.nvim_win_get_cursor(win)
+      return cursor[1] == 1 and cursor[2] == prompt_len
+    end)
+
+    local cursor = vim.api.nvim_win_get_cursor(win)
+
+    assert.are.equal(1, cursor[1])
+    assert.are.equal(prompt_len, cursor[2])
   end)
 
   it('renders the compact rename buffer as a single editable prompt line', function()

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -1,0 +1,178 @@
+describe("cosmic-ui.rename.model", function()
+  it("rejects empty submissions without dispatching rename", function()
+    local model = require("cosmic-ui.rename.model")
+    local result = model.normalize_submission("> ", "> ", "> ")
+
+    assert.are.same({ ok = false, reason = "empty" }, result)
+  end)
+
+  it("rejects unchanged submissions", function()
+    local model = require("cosmic-ui.rename.model")
+    local result = model.normalize_submission("> ", "> current_name", "current_name")
+
+    assert.are.same({ ok = false, reason = "unchanged" }, result)
+  end)
+end)
+
+describe("cosmic-ui.rename.ui", function()
+  local original_get_clients
+  local original_expand
+
+  local function stub_rename_context(current_name)
+    original_get_clients = vim.lsp.get_clients
+    original_expand = vim.fn.expand
+
+    vim.lsp.get_clients = function()
+      return {
+        { id = 1, name = "lua_ls" },
+      }
+    end
+
+    vim.fn.expand = function(expr)
+      if expr == "<cword>" then
+        return current_name
+      end
+
+      return original_expand(expr)
+    end
+  end
+
+  local function restore_rename_context()
+    if original_get_clients then
+      vim.lsp.get_clients = original_get_clients
+      original_get_clients = nil
+    end
+
+    if original_expand then
+      vim.fn.expand = original_expand
+      original_expand = nil
+    end
+  end
+
+  local function press(keys)
+    vim.api.nvim_feedkeys(vim.keycode(keys), "xt", false)
+  end
+
+  after_each(function()
+    restore_rename_context()
+
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      local config = vim.api.nvim_win_get_config(win)
+      if config.relative ~= "" then
+        pcall(vim.api.nvim_win_close, win, true)
+      end
+    end
+
+    vim.cmd("silent! only")
+  end)
+
+  it("restores focus to the origin window on submit", function()
+    stub_rename_context("current_name")
+
+    local ui = require("cosmic-ui.rename.ui")
+    local origin_win = vim.api.nvim_get_current_win()
+    local submitted
+
+    vim.cmd("split")
+    vim.api.nvim_set_current_win(origin_win)
+
+    ui.open({
+      default_value = "next_name",
+      on_submit = function(new_name)
+        submitted = {
+          name = new_name,
+          win = vim.api.nvim_get_current_win(),
+        }
+      end,
+    })
+
+    press("<CR>")
+    vim.wait(1000, function()
+      return submitted ~= nil
+    end)
+
+    assert.are.equal(origin_win, vim.api.nvim_get_current_win())
+    assert.are.same({
+      name = "next_name",
+      win = origin_win,
+    }, submitted)
+  end)
+
+  it("rejects empty submit from the panel without dispatching rename", function()
+    stub_rename_context("current_name")
+
+    local ui = require("cosmic-ui.rename.ui")
+    local submissions = 0
+
+    ui.open({
+      default_value = "",
+      on_submit = function()
+        submissions = submissions + 1
+      end,
+    })
+
+    press("<CR>")
+    vim.wait(1000, function()
+      local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
+      return vim.tbl_contains(lines, " Name cannot be empty ")
+    end)
+
+    assert.are.equal(0, submissions)
+    assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= "")
+    assert.is_true(vim.tbl_contains(
+      vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false),
+      " Name cannot be empty "
+    ))
+  end)
+
+  it("rejects unchanged submit from the panel without dispatching rename", function()
+    stub_rename_context("current_name")
+
+    local ui = require("cosmic-ui.rename.ui")
+    local submissions = 0
+
+    ui.open({
+      default_value = "current_name",
+      on_submit = function()
+        submissions = submissions + 1
+      end,
+    })
+
+    press("<CR>")
+    vim.wait(1000, function()
+      local lines = vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false)
+      return vim.tbl_contains(lines, " Name is unchanged ")
+    end)
+
+    assert.are.equal(0, submissions)
+    assert.is_true(vim.api.nvim_win_get_config(vim.api.nvim_get_current_win()).relative ~= "")
+    assert.is_true(vim.tbl_contains(
+      vim.api.nvim_buf_get_lines(vim.api.nvim_get_current_buf(), 0, -1, false),
+      " Name is unchanged "
+    ))
+  end)
+
+  it("restores focus to the origin window on cancel", function()
+    stub_rename_context("current_name")
+
+    local ui = require("cosmic-ui.rename.ui")
+    local origin_win = vim.api.nvim_get_current_win()
+
+    vim.cmd("split")
+    vim.api.nvim_set_current_win(origin_win)
+
+    ui.open({
+      default_value = "next_name",
+      on_submit = function()
+        error("rename should not submit on cancel")
+      end,
+    })
+
+    press("<Esc>")
+    vim.wait(1000, function()
+      return vim.api.nvim_get_current_win() == origin_win
+    end)
+
+    assert.are.equal(origin_win, vim.api.nvim_get_current_win())
+  end)
+end)

--- a/tests/rename/ui_spec.lua
+++ b/tests/rename/ui_spec.lua
@@ -134,13 +134,42 @@ describe('cosmic-ui.rename.ui', function()
       end,
     })
 
-    vim.cmd('normal! A2')
+    local buf = vim.api.nvim_get_current_buf()
+    vim.bo[buf].modifiable = true
+    vim.api.nvim_buf_set_text(buf, 2, 7, 2, 7, { '2' })
+    vim.bo[buf].modifiable = false
+
     press('<CR>')
     vim.wait(1000, function()
       return submitted ~= nil
     end)
 
     assert.are.equal('draft2', submitted)
+  end)
+
+  it('locks the panel outside insert mode so helper lines cannot be edited', function()
+    stub_rename_context('current_name')
+
+    local ui = require('cosmic-ui.rename.ui')
+
+    ui.open({
+      default_value = 'next_name',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    local before = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+
+    vim.cmd('stopinsert')
+    vim.wait(1000, function()
+      return vim.fn.mode() == 'n'
+    end)
+
+    local ok = pcall(vim.cmd, 'normal! G0rx')
+    local after = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+
+    assert.is_false(vim.bo[buf].modifiable)
+    assert.is_false(ok)
+    assert.are.same(before, after)
   end)
 
   it('preserves explicit window width and height overrides after render', function()

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -1,0 +1,8 @@
+describe("cosmic-ui.ui.panel", function()
+  it("builds a standard empty state row", function()
+    local states = require("cosmic-ui.ui.states")
+    local row = states.empty("No code actions found")
+    assert.are.equal("empty", row.state)
+    assert.are.equal("No code actions found", row.text)
+  end)
+end)

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -1,76 +1,76 @@
-describe("cosmic-ui.ui.panel", function()
-  it("builds a standard empty state row", function()
-    local states = require("cosmic-ui.ui.states")
-    local row = states.empty("No code actions found")
-    assert.are.equal("empty", row.state)
-    assert.are.equal("No code actions found", row.text)
+describe('cosmic-ui.ui.panel', function()
+  it('builds a standard empty state row', function()
+    local states = require('cosmic-ui.ui.states')
+    local row = states.empty('No code actions found')
+    assert.are.equal('empty', row.state)
+    assert.are.equal('No code actions found', row.text)
   end)
 
-  it("normalizes header, footer hints, and state rows into a stable panel model", function()
-    local panel = require("cosmic-ui.ui.panel")
+  it('normalizes header, footer hints, and state rows into a stable panel model', function()
+    local panel = require('cosmic-ui.ui.panel')
     local model = panel.build({
-      title = "Code Actions",
-      subtitle = "lua • 3 actions",
-      footer = { "Enter:apply", "Esc:close" },
-      rows = { { kind = "state", state = "empty", text = "No code actions found" } },
+      title = 'Code Actions',
+      subtitle = 'lua • 3 actions',
+      footer = { 'Enter:apply', 'Esc:close' },
+      rows = { { kind = 'state', state = 'empty', text = 'No code actions found' } },
     })
 
-    assert.are.equal("Code Actions", model.title)
-    assert.are.equal("lua • 3 actions", model.subtitle)
-    assert.are.equal("CosmicUiPanelTitle", model.title_highlight)
-    assert.are.equal("CosmicUiPanelSubtitle", model.subtitle_highlight)
+    assert.are.equal('Code Actions', model.title)
+    assert.are.equal('lua • 3 actions', model.subtitle)
+    assert.are.equal('CosmicUiPanelTitle', model.title_highlight)
+    assert.are.equal('CosmicUiPanelSubtitle', model.subtitle_highlight)
     assert.are.same({
       {
-        key = "Enter",
-        text = "apply",
-        key_highlight = "CosmicUiPanelHintKey",
-        text_highlight = "CosmicUiPanelHintText",
+        key = 'Enter',
+        text = 'apply',
+        key_highlight = 'CosmicUiPanelHintKey',
+        text_highlight = 'CosmicUiPanelHintText',
       },
       {
-        key = "Esc",
-        text = "close",
-        key_highlight = "CosmicUiPanelHintKey",
-        text_highlight = "CosmicUiPanelHintText",
+        key = 'Esc',
+        text = 'close',
+        key_highlight = 'CosmicUiPanelHintKey',
+        text_highlight = 'CosmicUiPanelHintText',
       },
     }, model.footer)
     assert.are.same({
-      kind = "state",
-      state = "empty",
-      text = "No code actions found",
-      highlight = "CosmicUiPanelStateInfo",
+      kind = 'state',
+      state = 'empty',
+      text = 'No code actions found',
+      highlight = 'CosmicUiPanelStateInfo',
     }, model.rows[1])
     assert.is_nil(model.selected)
   end)
 
-  it("fills in stable defaults for missing panel metadata", function()
-    local panel = require("cosmic-ui.ui.panel")
+  it('fills in stable defaults for missing panel metadata', function()
+    local panel = require('cosmic-ui.ui.panel')
     local model = panel.build({})
 
-    assert.are.equal("", model.title)
-    assert.are.equal("", model.subtitle)
-    assert.are.equal("CosmicUiPanelTitle", model.title_highlight)
-    assert.are.equal("CosmicUiPanelSubtitle", model.subtitle_highlight)
+    assert.are.equal('', model.title)
+    assert.are.equal('', model.subtitle)
+    assert.are.equal('CosmicUiPanelTitle', model.title_highlight)
+    assert.are.equal('CosmicUiPanelSubtitle', model.subtitle_highlight)
     assert.are.same({}, model.footer)
     assert.are.same({}, model.rows)
     assert.is_nil(model.selected)
   end)
 
-  it("prepares a panel by ensuring shared highlight links before returning the model", function()
-    local constants = require("cosmic-ui.ui.constants")
-    local panel = require("cosmic-ui.ui.panel")
+  it('prepares a panel by ensuring shared highlight links before returning the model', function()
+    local constants = require('cosmic-ui.ui.constants')
+    local panel = require('cosmic-ui.ui.panel')
 
     local model = panel.prepare({
-      footer = { "Enter:apply" },
-      rows = { { kind = "state", state = "error", text = "Request failed" } },
+      footer = { 'Enter:apply' },
+      rows = { { kind = 'state', state = 'error', text = 'Request failed' } },
     })
 
     assert.are.same({
-      key = "Enter",
-      text = "apply",
-      key_highlight = "CosmicUiPanelHintKey",
-      text_highlight = "CosmicUiPanelHintText",
+      key = 'Enter',
+      text = 'apply',
+      key_highlight = 'CosmicUiPanelHintKey',
+      text_highlight = 'CosmicUiPanelHintText',
     }, model.footer[1])
-    assert.are.equal("CosmicUiPanelStateError", model.rows[1].highlight)
+    assert.are.equal('CosmicUiPanelStateError', model.rows[1].highlight)
 
     for group, link in pairs(constants.highlight_links) do
       local hl = vim.api.nvim_get_hl(0, { name = group, link = true })
@@ -78,10 +78,10 @@ describe("cosmic-ui.ui.panel", function()
     end
   end)
 
-  it("restores focus through the panel-facing helper", function()
-    local panel = require("cosmic-ui.ui.panel")
+  it('restores focus through the panel-facing helper', function()
+    local panel = require('cosmic-ui.ui.panel')
     local first = vim.api.nvim_get_current_win()
-    vim.cmd("split")
+    vim.cmd('split')
     local second = vim.api.nvim_get_current_win()
 
     assert.are_not.equal(first, second)

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -6,7 +6,7 @@ describe("cosmic-ui.ui.panel", function()
     assert.are.equal("No code actions found", row.text)
   end)
 
-  it("normalizes panel metadata for title, subtitle, and footer hints", function()
+  it("normalizes header, footer hints, and state rows into a stable panel model", function()
     local panel = require("cosmic-ui.ui.panel")
     local model = panel.build({
       title = "Code Actions",
@@ -17,6 +17,44 @@ describe("cosmic-ui.ui.panel", function()
 
     assert.are.equal("Code Actions", model.title)
     assert.are.equal("lua • 3 actions", model.subtitle)
-    assert.are.same({ "Enter:apply", "Esc:close" }, model.footer)
+    assert.are.same({
+      { key = "Enter", text = "apply" },
+      { key = "Esc", text = "close" },
+    }, model.footer)
+    assert.are.same({
+      kind = "state",
+      state = "empty",
+      text = "No code actions found",
+      highlight = "CosmicUiPanelStateInfo",
+    }, model.rows[1])
+    assert.is_nil(model.selected)
+  end)
+
+  it("fills in stable defaults for missing panel metadata", function()
+    local panel = require("cosmic-ui.ui.panel")
+    local model = panel.build({})
+
+    assert.are.equal("", model.title)
+    assert.are.equal("", model.subtitle)
+    assert.are.same({}, model.footer)
+    assert.are.same({}, model.rows)
+    assert.is_nil(model.selected)
+  end)
+
+  it("prepares a panel by ensuring shared highlights before returning the model", function()
+    local highlights = require("cosmic-ui.ui.highlights")
+    local panel = require("cosmic-ui.ui.panel")
+    local spy = require("luassert.spy")
+    local ensure = spy.on(highlights, "ensure")
+
+    local model = panel.prepare({
+      footer = { "Enter:apply" },
+      rows = { { kind = "state", state = "error", text = "Request failed" } },
+    })
+
+    assert.spy(ensure).was.called(1)
+    assert.are.same({ key = "Enter", text = "apply" }, model.footer[1])
+    assert.are.equal("CosmicUiPanelStateError", model.rows[1].highlight)
+    ensure:revert()
   end)
 end)

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -92,6 +92,112 @@ describe('cosmic-ui.ui.panel', function()
     end
   end)
 
+  it('renders normalized footer entries into stable text and highlight spans', function()
+    local panel = require('cosmic-ui.ui.panel')
+    local footer = panel.build({
+      footer = {
+        'Enter:apply',
+        {
+          key = 'Esc',
+          text = 'close',
+          key_highlight = 'Special',
+          text_highlight = 'NormalFloat',
+        },
+      },
+    }).footer
+
+    local text, spans = panel.render_footer(footer)
+
+    assert.are.equal('Enter:apply  Esc:close', text)
+    assert.are.same({
+      {
+        highlight = 'CosmicUiPanelHintKey',
+        start_col = 0,
+        end_col = 5,
+      },
+      {
+        highlight = 'CosmicUiPanelHintText',
+        start_col = 6,
+        end_col = 11,
+      },
+      {
+        highlight = 'Special',
+        start_col = 13,
+        end_col = 16,
+      },
+      {
+        highlight = 'NormalFloat',
+        start_col = 17,
+        end_col = 22,
+      },
+    }, spans)
+  end)
+
+  it('prepares standard panel render output for sections, actions, states, and footer rows', function()
+    local panel = require('cosmic-ui.ui.panel')
+    local model = panel.build({
+      footer = {
+        'Enter:apply',
+        'Esc:close',
+      },
+      rows = {
+        { kind = 'state', state = 'warn', text = '1 source failed to return code actions' },
+        { kind = 'section', text = 'alpha' },
+        { kind = 'action', text = 'Fix A' },
+        { kind = 'separator', text = 'beta' },
+        { kind = 'action', text = 'Fix B' },
+      },
+    })
+
+    local prepared = panel.prepare_standard(model, { min_width = 30 })
+
+    assert.are.equal(40, prepared.width)
+    assert.are.equal(8, prepared.height)
+    assert.are.same({
+      ' 1 source failed to return code actions ',
+      '                 alpha                  ',
+      ' Fix A ',
+      '',
+      '                  beta                  ',
+      ' Fix B ',
+      '',
+      ' Enter:apply  Esc:close ',
+    }, prepared.lines)
+    assert.are.same({
+      [1] = { highlight = 'CosmicUiPanelStateWarn' },
+      [2] = { highlight = 'CosmicUiPanelSection' },
+      [5] = { highlight = 'CosmicUiPanelSection' },
+      [8] = {
+        spans = {
+          {
+            highlight = 'CosmicUiPanelHintKey',
+            start_col = 1,
+            end_col = 6,
+          },
+          {
+            highlight = 'CosmicUiPanelHintText',
+            start_col = 7,
+            end_col = 12,
+          },
+          {
+            highlight = 'CosmicUiPanelHintKey',
+            start_col = 14,
+            end_col = 17,
+          },
+          {
+            highlight = 'CosmicUiPanelHintText',
+            start_col = 18,
+            end_col = 23,
+          },
+        },
+      },
+    }, prepared.highlights)
+    assert.are.same({
+      [1] = 3,
+      [2] = 6,
+    }, prepared.action_line_by_idx)
+  end)
+
   it('restores focus through the panel-facing helper', function()
     local panel = require('cosmic-ui.ui.panel')
     local first = vim.api.nvim_get_current_win()

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -17,9 +17,21 @@ describe("cosmic-ui.ui.panel", function()
 
     assert.are.equal("Code Actions", model.title)
     assert.are.equal("lua • 3 actions", model.subtitle)
+    assert.are.equal("CosmicUiPanelTitle", model.title_highlight)
+    assert.are.equal("CosmicUiPanelSubtitle", model.subtitle_highlight)
     assert.are.same({
-      { key = "Enter", text = "apply" },
-      { key = "Esc", text = "close" },
+      {
+        key = "Enter",
+        text = "apply",
+        key_highlight = "CosmicUiPanelHintKey",
+        text_highlight = "CosmicUiPanelHintText",
+      },
+      {
+        key = "Esc",
+        text = "close",
+        key_highlight = "CosmicUiPanelHintKey",
+        text_highlight = "CosmicUiPanelHintText",
+      },
     }, model.footer)
     assert.are.same({
       kind = "state",
@@ -36,25 +48,47 @@ describe("cosmic-ui.ui.panel", function()
 
     assert.are.equal("", model.title)
     assert.are.equal("", model.subtitle)
+    assert.are.equal("CosmicUiPanelTitle", model.title_highlight)
+    assert.are.equal("CosmicUiPanelSubtitle", model.subtitle_highlight)
     assert.are.same({}, model.footer)
     assert.are.same({}, model.rows)
     assert.is_nil(model.selected)
   end)
 
-  it("prepares a panel by ensuring shared highlights before returning the model", function()
-    local highlights = require("cosmic-ui.ui.highlights")
+  it("prepares a panel by ensuring shared highlight links before returning the model", function()
+    local constants = require("cosmic-ui.ui.constants")
     local panel = require("cosmic-ui.ui.panel")
-    local spy = require("luassert.spy")
-    local ensure = spy.on(highlights, "ensure")
 
     local model = panel.prepare({
       footer = { "Enter:apply" },
       rows = { { kind = "state", state = "error", text = "Request failed" } },
     })
 
-    assert.spy(ensure).was.called(1)
-    assert.are.same({ key = "Enter", text = "apply" }, model.footer[1])
+    assert.are.same({
+      key = "Enter",
+      text = "apply",
+      key_highlight = "CosmicUiPanelHintKey",
+      text_highlight = "CosmicUiPanelHintText",
+    }, model.footer[1])
     assert.are.equal("CosmicUiPanelStateError", model.rows[1].highlight)
-    ensure:revert()
+
+    for group, link in pairs(constants.highlight_links) do
+      local hl = vim.api.nvim_get_hl(0, { name = group, link = true })
+      assert.are.equal(link, hl.link)
+    end
+  end)
+
+  it("restores focus through the panel-facing helper", function()
+    local panel = require("cosmic-ui.ui.panel")
+    local first = vim.api.nvim_get_current_win()
+    vim.cmd("split")
+    local second = vim.api.nvim_get_current_win()
+
+    assert.are_not.equal(first, second)
+
+    panel.restore_focus(first)
+    assert.are.equal(first, vim.api.nvim_get_current_win())
+
+    vim.api.nvim_win_close(second, true)
   end)
 end)

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -62,6 +62,13 @@ describe('cosmic-ui.ui.panel', function()
     assert.is_nil(model.selected)
   end)
 
+  it('defaults panel layout to standard and preserves compact when requested', function()
+    local panel = require('cosmic-ui.ui.panel')
+
+    assert.are.equal('standard', panel.build({}).layout)
+    assert.are.equal('compact', panel.build({ layout = 'compact' }).layout)
+  end)
+
   it('prepares a panel by ensuring shared highlight links before returning the model', function()
     local constants = require('cosmic-ui.ui.constants')
     local panel = require('cosmic-ui.ui.panel')

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -5,4 +5,18 @@ describe("cosmic-ui.ui.panel", function()
     assert.are.equal("empty", row.state)
     assert.are.equal("No code actions found", row.text)
   end)
+
+  it("normalizes panel metadata for title, subtitle, and footer hints", function()
+    local panel = require("cosmic-ui.ui.panel")
+    local model = panel.build({
+      title = "Code Actions",
+      subtitle = "lua • 3 actions",
+      footer = { "Enter:apply", "Esc:close" },
+      rows = { { kind = "state", state = "empty", text = "No code actions found" } },
+    })
+
+    assert.are.equal("Code Actions", model.title)
+    assert.are.equal("lua • 3 actions", model.subtitle)
+    assert.are.same({ "Enter:apply", "Esc:close" }, model.footer)
+  end)
 end)

--- a/tests/ui/panel_spec.lua
+++ b/tests/ui/panel_spec.lua
@@ -1,4 +1,11 @@
 describe('cosmic-ui.ui.panel', function()
+  it('keeps hotkey helper text readable in shared panels', function()
+    local constants = require('cosmic-ui.ui.constants')
+
+    assert.are.equal('Special', constants.highlight_links.CosmicUiPanelHintKey)
+    assert.are.equal('NormalFloat', constants.highlight_links.CosmicUiPanelHintText)
+  end)
+
   it('builds a standard empty state row', function()
     local states = require('cosmic-ui.ui.states')
     local row = states.empty('No code actions found')


### PR DESCRIPTION
## Summary
- add shared panel infrastructure plus headless coverage for panel, command, codeactions, rename, and formatter UI behavior
- migrate codeactions, rename, and formatters to the polished Cosmic panel language while preserving config compatibility and async dismissal behavior
- add optional `:CosmicRename`, `:CosmicCodeActions`, `:CosmicFormatters`, and `:CosmicFormat` commands and update help/Markdown docs to match

## Test Plan
- [x] `stylua lua plugin tests`
- [x] `nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests { minimal_init = 'tests/minimal_init.lua' }" -c qa`